### PR TITLE
feat(localization): add support for command name, description, and argument localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and provide details for each command, such as name, description, role and permis
 ## Key Features
 - Consolidating various attributes from `InvokableApplicationCommand` and `APIApplicationCommand` into a single cached object.
 - Parsing role and permission checks.
-- Ready-to-use methods for populating autocomplete outputs.
+- Support localizing commands and arguments (*New in version 0.3.0*)
 - Utility functions that provide ready-to-go embeds and pagination.
 
 

--- a/docs/css/material.css
+++ b/docs/css/material.css
@@ -1,4 +1,0 @@
-/* More space at the bottom of the page. */
-.md-main__inner {
-    margin-bottom: 1.5rem;
-}

--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -1,6 +1,0 @@
-/* Indentation. */
-div.doc-contents:not(.first) {
-    padding-left: 25px;
-    border-left: 4px solid rgba(230, 230, 230);
-    margin-bottom: 80px;
-}

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ and provide details for each command, such as name, description, role and permis
 ## Key Features
 - Consolidating various attributes from `InvokableApplicationCommand` and `APIApplicationCommand` into a single cached object.
 - Parsing role and permission checks.
-- Ready-to-use methods for populating autocomplete outputs.
+- Support localizing commands and arguments (*New in version 0.3.0*)
 - Utility functions that provide ready-to-go embeds and pagination.
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,12 +16,20 @@ nav:
 
 
 
+
 theme:
   favicon: assets/favicon.svg
   name: material
   features:
+  - content.code.copy
+  - navigation.sections
   - navigation.tabs
   - navigation.top
+  - search.share
+  - search.suggest
+  font:
+    text: Roboto
+    code: Roboto Mono
   palette:
   - media: "(prefers-color-scheme: light)"
     scheme: default
@@ -39,29 +47,22 @@ theme:
       name: Switch to light mode
 
 
-extra_css:
-  - css/material.css
-  - css/mkdocstrings.css
-  # - css/logo.css
-
-
 markdown_extensions:
   - pymdownx.superfences
-  - pymdownx.details
-  - pymdownx.tilde
-  - pymdownx.emoji
-  - mdx_truly_sane_lists
-  - tables
-  - def_list
   - admonition
   - attr_list
   - md_in_html
+  - toc:
+      permalink: true
 
 
 
 plugins:
-  - search
-  - autorefs
+  - search:
+      separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
+  - minify:
+      minify_html: true
+
   - gen-files:
       scripts:
       - docs/gen_raf_nav.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -343,6 +343,16 @@ files = [
 ]
 
 [[package]]
+name = "csscompressor"
+version = "0.9.5"
+description = "A python port of YUI CSS Compressor"
+optional = false
+python-versions = "*"
+files = [
+    {file = "csscompressor-0.9.5.tar.gz", hash = "sha256:afa22badbcf3120a4f392e4d22f9fff485c044a1feda4a950ecc5eba9dd31a05"},
+]
+
+[[package]]
 name = "disnake"
 version = "2.9.0"
 description = "A Python wrapper for the Discord API"
@@ -493,6 +503,16 @@ files = [
 colorama = ">=0.4"
 
 [[package]]
+name = "htmlmin2"
+version = "0.1.13"
+description = "An HTML Minifier"
+optional = false
+python-versions = "*"
+files = [
+    {file = "htmlmin2-0.1.13-py3-none-any.whl", hash = "sha256:75609f2a42e64f7ce57dbff28a39890363bde9e7e5885db633317efbdf8c79a2"},
+]
+
+[[package]]
 name = "identify"
 version = "2.5.27"
 description = "File identification library for Python"
@@ -571,6 +591,16 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "jsmin"
+version = "3.0.1"
+description = "JavaScript minifier."
+optional = false
+python-versions = "*"
+files = [
+    {file = "jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc"},
+]
+
+[[package]]
 name = "markdown"
 version = "3.4.4"
 description = "Python implementation of John Gruber's Markdown."
@@ -646,20 +676,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp39-cp39-win_amd64.whl", hash = "sha256:3fd4abcb888d15a94f32b75d8fd18ee162ca0c064f35b11134be77050296d6ba"},
     {file = "MarkupSafe-2.1.3.tar.gz", hash = "sha256:af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"},
 ]
-
-[[package]]
-name = "mdx-truly-sane-lists"
-version = "1.3"
-description = "Extension for Python-Markdown that makes lists truly sane. Custom indents for nested lists and fix for messy linebreaks."
-optional = false
-python-versions = "*"
-files = [
-    {file = "mdx_truly_sane_lists-1.3-py3-none-any.whl", hash = "sha256:b9546a4c40ff8f1ab692f77cee4b6bfe8ddf9cccf23f0a24e71f3716fe290a37"},
-    {file = "mdx_truly_sane_lists-1.3.tar.gz", hash = "sha256:b661022df7520a1e113af7c355c62216b384c867e4f59fb8ee7ad511e6e77f45"},
-]
-
-[package.dependencies]
-Markdown = ">=2.6"
 
 [[package]]
 name = "mergedeep"
@@ -794,6 +810,23 @@ files = [
     {file = "mkdocs_material_extensions-1.1.1-py3-none-any.whl", hash = "sha256:e41d9f38e4798b6617ad98ca8f7f1157b1e4385ac1459ca1e4ea219b556df945"},
     {file = "mkdocs_material_extensions-1.1.1.tar.gz", hash = "sha256:9c003da71e2cc2493d910237448c672e00cefc800d3d6ae93d2fc69979e3bd93"},
 ]
+
+[[package]]
+name = "mkdocs-minify-plugin"
+version = "0.7.1"
+description = "An MkDocs plugin to minify HTML, JS or CSS files prior to being written to disk"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mkdocs-minify-plugin-0.7.1.tar.gz", hash = "sha256:6abf8f5a0fddb476bddd38faba28390fd8c41ab63b0d7202e3ce3deeb9ab98cb"},
+    {file = "mkdocs_minify_plugin-0.7.1-py3-none-any.whl", hash = "sha256:29bd6a1aa5b0217a55b08333194e20cf1ff83b63fb6a22a33f10f8fa9745c28a"},
+]
+
+[package.dependencies]
+csscompressor = ">=0.9.5"
+htmlmin2 = ">=0.1.13"
+jsmin = ">=3.0.1"
+mkdocs = ">=1.4.1"
 
 [[package]]
 name = "mkdocstrings"
@@ -1536,4 +1569,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "c42a7b45391b747de82d1d2ed7b733e449dab314fa2c8030587d60c81b4ba160"
+content-hash = "0ff24539c447a456907baf4c1f0195dc8d99f2c678485fed7ed30e29990db607"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1044,13 +1044,13 @@ extra = ["pygments (>=2.12)"]
 
 [[package]]
 name = "pyright"
-version = "1.1.325"
+version = "1.1.326"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.325-py3-none-any.whl", hash = "sha256:8f3ab88ba4843f053ab5b5c886d676161aba6f446776bfb57cc0434ed4d88672"},
-    {file = "pyright-1.1.325.tar.gz", hash = "sha256:879a3f66944ffd59d3facd54872fed814830fed64daf3e8eb71b146ddd83bb67"},
+    {file = "pyright-1.1.326-py3-none-any.whl", hash = "sha256:f3c5047465138558d3d106a9464cc097cf2c3611da6edcf5b535cc1fdebd45db"},
+    {file = "pyright-1.1.326.tar.gz", hash = "sha256:cecbe026b14034ba0750db605718a8c2605552387c5772dfaf7f3e632cb7212a"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -480,13 +480,13 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "griffe"
-version = "0.36.0"
+version = "0.36.1"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.36.0-py3-none-any.whl", hash = "sha256:4235df397b7b56192cbfda601e458526279bdaf3bf1f59d0be368abac72bf42d"},
-    {file = "griffe-0.36.0.tar.gz", hash = "sha256:ccf062126041d19cc4d9850ca46a555a656e738f5e83feb78f36b05fec5974ad"},
+    {file = "griffe-0.36.1-py3-none-any.whl", hash = "sha256:859b653fcde0a0af0e841a0109bac2b63a2f683132ae1ec8dae5fa81e94617a0"},
+    {file = "griffe-0.36.1.tar.gz", hash = "sha256:11df63f1c85f605c73e4485de70ec13784049695d228241b0b582364a20c0536"},
 ]
 
 [package.dependencies]
@@ -762,27 +762,27 @@ pyyaml = "*"
 
 [[package]]
 name = "mkdocs-material"
-version = "9.2.7"
+version = "9.2.8"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "mkdocs_material-9.2.7-py3-none-any.whl", hash = "sha256:92e4160d191cc76121fed14ab9f14638e43a6da0f2e9d7a9194d377f0a4e7f18"},
-    {file = "mkdocs_material-9.2.7.tar.gz", hash = "sha256:b44da35b0d98cd762d09ef74f1ddce5b6d6e35c13f13beb0c9d82a629e5f229e"},
+    {file = "mkdocs_material-9.2.8-py3-none-any.whl", hash = "sha256:6bc8524f8047a4f060d6ab0925b9d7cb61b3b5e6d5ca8a8e8085f8bfdeca1b71"},
+    {file = "mkdocs_material-9.2.8.tar.gz", hash = "sha256:ec839dc5eaf42d8525acd1d6420fd0a0583671a4f98a9b3ff7897ae8628dbc2d"},
 ]
 
 [package.dependencies]
-babel = ">=2.10,<3.0"
+babel = ">=2.12,<3.0"
 colorama = ">=0.4,<1.0"
-jinja2 = ">=3.0,<4.0"
-markdown = ">=3.2,<4.0"
+jinja2 = ">=3.1,<4.0"
+markdown = ">=3.4,<4.0"
 mkdocs = ">=1.5,<2.0"
 mkdocs-material-extensions = ">=1.1,<2.0"
 paginate = ">=0.5,<1.0"
 pygments = ">=2.16,<3.0"
-pymdown-extensions = ">=10.2,<11.0"
-regex = ">=2022.4,<2023.0"
-requests = ">=2.26,<3.0"
+pymdown-extensions = ">=10.3,<11.0"
+regex = ">=2023.8,<2024.0"
+requests = ">=2.31,<3.0"
 
 [[package]]
 name = "mkdocs-material-extensions"
@@ -824,13 +824,13 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.6.0"
+version = "1.6.2"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings_python-1.6.0-py3-none-any.whl", hash = "sha256:06f116112b335114372f2554b1bf61b709c74ab72605010e1605c1086932dffe"},
-    {file = "mkdocstrings_python-1.6.0.tar.gz", hash = "sha256:6164ccaa6e488abc2a8fbccdfd1f21948c2c344d3f347847783a5d1c6fa2bfbf"},
+    {file = "mkdocstrings_python-1.6.2-py3-none-any.whl", hash = "sha256:cf560df975faf712808e44c1c2e52b8267f17bc89c8b23e7b9bfe679561adf4d"},
+    {file = "mkdocstrings_python-1.6.2.tar.gz", hash = "sha256:edf0f81899bee8024971bf2c18b6fc17f66085992f01c72840a3ee0ee42113fb"},
 ]
 
 [package.dependencies]
@@ -1090,13 +1090,13 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
-version = "2023.3"
+version = "2023.3.post1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
-    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
 ]
 
 [[package]]
@@ -1164,99 +1164,99 @@ pyyaml = "*"
 
 [[package]]
 name = "regex"
-version = "2022.10.31"
+version = "2023.8.8"
 description = "Alternative regular expression module, to replace re."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "regex-2022.10.31-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a8ff454ef0bb061e37df03557afda9d785c905dab15584860f982e88be73015f"},
-    {file = "regex-2022.10.31-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1eba476b1b242620c266edf6325b443a2e22b633217a9835a52d8da2b5c051f9"},
-    {file = "regex-2022.10.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0e5af9a9effb88535a472e19169e09ce750c3d442fb222254a276d77808620b"},
-    {file = "regex-2022.10.31-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d03fe67b2325cb3f09be029fd5da8df9e6974f0cde2c2ac6a79d2634e791dd57"},
-    {file = "regex-2022.10.31-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a9d0b68ac1743964755ae2d89772c7e6fb0118acd4d0b7464eaf3921c6b49dd4"},
-    {file = "regex-2022.10.31-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a45b6514861916c429e6059a55cf7db74670eaed2052a648e3e4d04f070e001"},
-    {file = "regex-2022.10.31-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8b0886885f7323beea6f552c28bff62cbe0983b9fbb94126531693ea6c5ebb90"},
-    {file = "regex-2022.10.31-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5aefb84a301327ad115e9d346c8e2760009131d9d4b4c6b213648d02e2abe144"},
-    {file = "regex-2022.10.31-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:702d8fc6f25bbf412ee706bd73019da5e44a8400861dfff7ff31eb5b4a1276dc"},
-    {file = "regex-2022.10.31-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a3c1ebd4ed8e76e886507c9eddb1a891673686c813adf889b864a17fafcf6d66"},
-    {file = "regex-2022.10.31-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:50921c140561d3db2ab9f5b11c5184846cde686bb5a9dc64cae442926e86f3af"},
-    {file = "regex-2022.10.31-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:7db345956ecce0c99b97b042b4ca7326feeec6b75facd8390af73b18e2650ffc"},
-    {file = "regex-2022.10.31-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:763b64853b0a8f4f9cfb41a76a4a85a9bcda7fdda5cb057016e7706fde928e66"},
-    {file = "regex-2022.10.31-cp310-cp310-win32.whl", hash = "sha256:44136355e2f5e06bf6b23d337a75386371ba742ffa771440b85bed367c1318d1"},
-    {file = "regex-2022.10.31-cp310-cp310-win_amd64.whl", hash = "sha256:bfff48c7bd23c6e2aec6454aaf6edc44444b229e94743b34bdcdda2e35126cf5"},
-    {file = "regex-2022.10.31-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b4b1fe58cd102d75ef0552cf17242705ce0759f9695334a56644ad2d83903fe"},
-    {file = "regex-2022.10.31-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:542e3e306d1669b25936b64917285cdffcd4f5c6f0247636fec037187bd93542"},
-    {file = "regex-2022.10.31-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c27cc1e4b197092e50ddbf0118c788d9977f3f8f35bfbbd3e76c1846a3443df7"},
-    {file = "regex-2022.10.31-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b8e38472739028e5f2c3a4aded0ab7eadc447f0d84f310c7a8bb697ec417229e"},
-    {file = "regex-2022.10.31-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:76c598ca73ec73a2f568e2a72ba46c3b6c8690ad9a07092b18e48ceb936e9f0c"},
-    {file = "regex-2022.10.31-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c28d3309ebd6d6b2cf82969b5179bed5fefe6142c70f354ece94324fa11bf6a1"},
-    {file = "regex-2022.10.31-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9af69f6746120998cd9c355e9c3c6aec7dff70d47247188feb4f829502be8ab4"},
-    {file = "regex-2022.10.31-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a5f9505efd574d1e5b4a76ac9dd92a12acb2b309551e9aa874c13c11caefbe4f"},
-    {file = "regex-2022.10.31-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:5ff525698de226c0ca743bfa71fc6b378cda2ddcf0d22d7c37b1cc925c9650a5"},
-    {file = "regex-2022.10.31-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:4fe7fda2fe7c8890d454f2cbc91d6c01baf206fbc96d89a80241a02985118c0c"},
-    {file = "regex-2022.10.31-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:2cdc55ca07b4e70dda898d2ab7150ecf17c990076d3acd7a5f3b25cb23a69f1c"},
-    {file = "regex-2022.10.31-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:44a6c2f6374e0033873e9ed577a54a3602b4f609867794c1a3ebba65e4c93ee7"},
-    {file = "regex-2022.10.31-cp311-cp311-win32.whl", hash = "sha256:d8716f82502997b3d0895d1c64c3b834181b1eaca28f3f6336a71777e437c2af"},
-    {file = "regex-2022.10.31-cp311-cp311-win_amd64.whl", hash = "sha256:61edbca89aa3f5ef7ecac8c23d975fe7261c12665f1d90a6b1af527bba86ce61"},
-    {file = "regex-2022.10.31-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0a069c8483466806ab94ea9068c34b200b8bfc66b6762f45a831c4baaa9e8cdd"},
-    {file = "regex-2022.10.31-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d26166acf62f731f50bdd885b04b38828436d74e8e362bfcb8df221d868b5d9b"},
-    {file = "regex-2022.10.31-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac741bf78b9bb432e2d314439275235f41656e189856b11fb4e774d9f7246d81"},
-    {file = "regex-2022.10.31-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75f591b2055523fc02a4bbe598aa867df9e953255f0b7f7715d2a36a9c30065c"},
-    {file = "regex-2022.10.31-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b30bddd61d2a3261f025ad0f9ee2586988c6a00c780a2fb0a92cea2aa702c54"},
-    {file = "regex-2022.10.31-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ef4163770525257876f10e8ece1cf25b71468316f61451ded1a6f44273eedeb5"},
-    {file = "regex-2022.10.31-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7b280948d00bd3973c1998f92e22aa3ecb76682e3a4255f33e1020bd32adf443"},
-    {file = "regex-2022.10.31-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:d0213671691e341f6849bf33cd9fad21f7b1cb88b89e024f33370733fec58742"},
-    {file = "regex-2022.10.31-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:22e7ebc231d28393dfdc19b185d97e14a0f178bedd78e85aad660e93b646604e"},
-    {file = "regex-2022.10.31-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:8ad241da7fac963d7573cc67a064c57c58766b62a9a20c452ca1f21050868dfa"},
-    {file = "regex-2022.10.31-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:586b36ebda81e6c1a9c5a5d0bfdc236399ba6595e1397842fd4a45648c30f35e"},
-    {file = "regex-2022.10.31-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:0653d012b3bf45f194e5e6a41df9258811ac8fc395579fa82958a8b76286bea4"},
-    {file = "regex-2022.10.31-cp36-cp36m-win32.whl", hash = "sha256:144486e029793a733e43b2e37df16a16df4ceb62102636ff3db6033994711066"},
-    {file = "regex-2022.10.31-cp36-cp36m-win_amd64.whl", hash = "sha256:c14b63c9d7bab795d17392c7c1f9aaabbffd4cf4387725a0ac69109fb3b550c6"},
-    {file = "regex-2022.10.31-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4cac3405d8dda8bc6ed499557625585544dd5cbf32072dcc72b5a176cb1271c8"},
-    {file = "regex-2022.10.31-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23cbb932cc53a86ebde0fb72e7e645f9a5eec1a5af7aa9ce333e46286caef783"},
-    {file = "regex-2022.10.31-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74bcab50a13960f2a610cdcd066e25f1fd59e23b69637c92ad470784a51b1347"},
-    {file = "regex-2022.10.31-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78d680ef3e4d405f36f0d6d1ea54e740366f061645930072d39bca16a10d8c93"},
-    {file = "regex-2022.10.31-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce6910b56b700bea7be82c54ddf2e0ed792a577dfaa4a76b9af07d550af435c6"},
-    {file = "regex-2022.10.31-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:659175b2144d199560d99a8d13b2228b85e6019b6e09e556209dfb8c37b78a11"},
-    {file = "regex-2022.10.31-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1ddf14031a3882f684b8642cb74eea3af93a2be68893901b2b387c5fd92a03ec"},
-    {file = "regex-2022.10.31-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:b683e5fd7f74fb66e89a1ed16076dbab3f8e9f34c18b1979ded614fe10cdc4d9"},
-    {file = "regex-2022.10.31-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:2bde29cc44fa81c0a0c8686992c3080b37c488df167a371500b2a43ce9f026d1"},
-    {file = "regex-2022.10.31-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:4919899577ba37f505aaebdf6e7dc812d55e8f097331312db7f1aab18767cce8"},
-    {file = "regex-2022.10.31-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:9c94f7cc91ab16b36ba5ce476f1904c91d6c92441f01cd61a8e2729442d6fcf5"},
-    {file = "regex-2022.10.31-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ae1e96785696b543394a4e3f15f3f225d44f3c55dafe3f206493031419fedf95"},
-    {file = "regex-2022.10.31-cp37-cp37m-win32.whl", hash = "sha256:c670f4773f2f6f1957ff8a3962c7dd12e4be54d05839b216cb7fd70b5a1df394"},
-    {file = "regex-2022.10.31-cp37-cp37m-win_amd64.whl", hash = "sha256:8e0caeff18b96ea90fc0eb6e3bdb2b10ab5b01a95128dfeccb64a7238decf5f0"},
-    {file = "regex-2022.10.31-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:131d4be09bea7ce2577f9623e415cab287a3c8e0624f778c1d955ec7c281bd4d"},
-    {file = "regex-2022.10.31-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e613a98ead2005c4ce037c7b061f2409a1a4e45099edb0ef3200ee26ed2a69a8"},
-    {file = "regex-2022.10.31-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:052b670fafbe30966bbe5d025e90b2a491f85dfe5b2583a163b5e60a85a321ad"},
-    {file = "regex-2022.10.31-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aa62a07ac93b7cb6b7d0389d8ef57ffc321d78f60c037b19dfa78d6b17c928ee"},
-    {file = "regex-2022.10.31-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5352bea8a8f84b89d45ccc503f390a6be77917932b1c98c4cdc3565137acc714"},
-    {file = "regex-2022.10.31-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20f61c9944f0be2dc2b75689ba409938c14876c19d02f7585af4460b6a21403e"},
-    {file = "regex-2022.10.31-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29c04741b9ae13d1e94cf93fca257730b97ce6ea64cfe1eba11cf9ac4e85afb6"},
-    {file = "regex-2022.10.31-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:543883e3496c8b6d58bd036c99486c3c8387c2fc01f7a342b760c1ea3158a318"},
-    {file = "regex-2022.10.31-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b7a8b43ee64ca8f4befa2bea4083f7c52c92864d8518244bfa6e88c751fa8fff"},
-    {file = "regex-2022.10.31-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6a9a19bea8495bb419dc5d38c4519567781cd8d571c72efc6aa959473d10221a"},
-    {file = "regex-2022.10.31-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:6ffd55b5aedc6f25fd8d9f905c9376ca44fcf768673ffb9d160dd6f409bfda73"},
-    {file = "regex-2022.10.31-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:4bdd56ee719a8f751cf5a593476a441c4e56c9b64dc1f0f30902858c4ef8771d"},
-    {file = "regex-2022.10.31-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8ca88da1bd78990b536c4a7765f719803eb4f8f9971cc22d6ca965c10a7f2c4c"},
-    {file = "regex-2022.10.31-cp38-cp38-win32.whl", hash = "sha256:5a260758454580f11dd8743fa98319bb046037dfab4f7828008909d0aa5292bc"},
-    {file = "regex-2022.10.31-cp38-cp38-win_amd64.whl", hash = "sha256:5e6a5567078b3eaed93558842346c9d678e116ab0135e22eb72db8325e90b453"},
-    {file = "regex-2022.10.31-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5217c25229b6a85049416a5c1e6451e9060a1edcf988641e309dbe3ab26d3e49"},
-    {file = "regex-2022.10.31-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4bf41b8b0a80708f7e0384519795e80dcb44d7199a35d52c15cc674d10b3081b"},
-    {file = "regex-2022.10.31-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cf0da36a212978be2c2e2e2d04bdff46f850108fccc1851332bcae51c8907cc"},
-    {file = "regex-2022.10.31-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d403d781b0e06d2922435ce3b8d2376579f0c217ae491e273bab8d092727d244"},
-    {file = "regex-2022.10.31-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a37d51fa9a00d265cf73f3de3930fa9c41548177ba4f0faf76e61d512c774690"},
-    {file = "regex-2022.10.31-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4f781ffedd17b0b834c8731b75cce2639d5a8afe961c1e58ee7f1f20b3af185"},
-    {file = "regex-2022.10.31-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d243b36fbf3d73c25e48014961e83c19c9cc92530516ce3c43050ea6276a2ab7"},
-    {file = "regex-2022.10.31-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:370f6e97d02bf2dd20d7468ce4f38e173a124e769762d00beadec3bc2f4b3bc4"},
-    {file = "regex-2022.10.31-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:597f899f4ed42a38df7b0e46714880fb4e19a25c2f66e5c908805466721760f5"},
-    {file = "regex-2022.10.31-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7dbdce0c534bbf52274b94768b3498abdf675a691fec5f751b6057b3030f34c1"},
-    {file = "regex-2022.10.31-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:22960019a842777a9fa5134c2364efaed5fbf9610ddc5c904bd3a400973b0eb8"},
-    {file = "regex-2022.10.31-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:7f5a3ffc731494f1a57bd91c47dc483a1e10048131ffb52d901bfe2beb6102e8"},
-    {file = "regex-2022.10.31-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7ef6b5942e6bfc5706301a18a62300c60db9af7f6368042227ccb7eeb22d0892"},
-    {file = "regex-2022.10.31-cp39-cp39-win32.whl", hash = "sha256:395161bbdbd04a8333b9ff9763a05e9ceb4fe210e3c7690f5e68cedd3d65d8e1"},
-    {file = "regex-2022.10.31-cp39-cp39-win_amd64.whl", hash = "sha256:957403a978e10fb3ca42572a23e6f7badff39aa1ce2f4ade68ee452dc6807692"},
-    {file = "regex-2022.10.31.tar.gz", hash = "sha256:a3a98921da9a1bf8457aeee6a551948a83601689e5ecdd736894ea9bbec77e83"},
+    {file = "regex-2023.8.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:88900f521c645f784260a8d346e12a1590f79e96403971241e64c3a265c8ecdb"},
+    {file = "regex-2023.8.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3611576aff55918af2697410ff0293d6071b7e00f4b09e005d614686ac4cd57c"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b8a0ccc8f2698f120e9e5742f4b38dc944c38744d4bdfc427616f3a163dd9de5"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c662a4cbdd6280ee56f841f14620787215a171c4e2d1744c9528bed8f5816c96"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cf0633e4a1b667bfe0bb10b5e53fe0d5f34a6243ea2530eb342491f1adf4f739"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:551ad543fa19e94943c5b2cebc54c73353ffff08228ee5f3376bd27b3d5b9800"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54de2619f5ea58474f2ac211ceea6b615af2d7e4306220d4f3fe690c91988a61"},
+    {file = "regex-2023.8.8-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5ec4b3f0aebbbe2fc0134ee30a791af522a92ad9f164858805a77442d7d18570"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:3ae646c35cb9f820491760ac62c25b6d6b496757fda2d51be429e0e7b67ae0ab"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ca339088839582d01654e6f83a637a4b8194d0960477b9769d2ff2cfa0fa36d2"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:d9b6627408021452dcd0d2cdf8da0534e19d93d070bfa8b6b4176f99711e7f90"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:bd3366aceedf274f765a3a4bc95d6cd97b130d1dda524d8f25225d14123c01db"},
+    {file = "regex-2023.8.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7aed90a72fc3654fba9bc4b7f851571dcc368120432ad68b226bd593f3f6c0b7"},
+    {file = "regex-2023.8.8-cp310-cp310-win32.whl", hash = "sha256:80b80b889cb767cc47f31d2b2f3dec2db8126fbcd0cff31b3925b4dc6609dcdb"},
+    {file = "regex-2023.8.8-cp310-cp310-win_amd64.whl", hash = "sha256:b82edc98d107cbc7357da7a5a695901b47d6eb0420e587256ba3ad24b80b7d0b"},
+    {file = "regex-2023.8.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1e7d84d64c84ad97bf06f3c8cb5e48941f135ace28f450d86af6b6512f1c9a71"},
+    {file = "regex-2023.8.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ce0f9fbe7d295f9922c0424a3637b88c6c472b75eafeaff6f910494a1fa719ef"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06c57e14ac723b04458df5956cfb7e2d9caa6e9d353c0b4c7d5d54fcb1325c46"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7a9aaa5a1267125eef22cef3b63484c3241aaec6f48949b366d26c7250e0357"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b7408511fca48a82a119d78a77c2f5eb1b22fe88b0d2450ed0756d194fe7a9a"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14dc6f2d88192a67d708341f3085df6a4f5a0c7b03dec08d763ca2cd86e9f559"},
+    {file = "regex-2023.8.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48c640b99213643d141550326f34f0502fedb1798adb3c9eb79650b1ecb2f177"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0085da0f6c6393428bf0d9c08d8b1874d805bb55e17cb1dfa5ddb7cfb11140bf"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:964b16dcc10c79a4a2be9f1273fcc2684a9eedb3906439720598029a797b46e6"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7ce606c14bb195b0e5108544b540e2c5faed6843367e4ab3deb5c6aa5e681208"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:40f029d73b10fac448c73d6eb33d57b34607f40116e9f6e9f0d32e9229b147d7"},
+    {file = "regex-2023.8.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3b8e6ea6be6d64104d8e9afc34c151926f8182f84e7ac290a93925c0db004bfd"},
+    {file = "regex-2023.8.8-cp311-cp311-win32.whl", hash = "sha256:942f8b1f3b223638b02df7df79140646c03938d488fbfb771824f3d05fc083a8"},
+    {file = "regex-2023.8.8-cp311-cp311-win_amd64.whl", hash = "sha256:51d8ea2a3a1a8fe4f67de21b8b93757005213e8ac3917567872f2865185fa7fb"},
+    {file = "regex-2023.8.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e951d1a8e9963ea51efd7f150450803e3b95db5939f994ad3d5edac2b6f6e2b4"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:704f63b774218207b8ccc6c47fcef5340741e5d839d11d606f70af93ee78e4d4"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22283c769a7b01c8ac355d5be0715bf6929b6267619505e289f792b01304d898"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:91129ff1bb0619bc1f4ad19485718cc623a2dc433dff95baadbf89405c7f6b57"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de35342190deb7b866ad6ba5cbcccb2d22c0487ee0cbb251efef0843d705f0d4"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b993b6f524d1e274a5062488a43e3f9f8764ee9745ccd8e8193df743dbe5ee61"},
+    {file = "regex-2023.8.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3026cbcf11d79095a32d9a13bbc572a458727bd5b1ca332df4a79faecd45281c"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:293352710172239bf579c90a9864d0df57340b6fd21272345222fb6371bf82b3"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d909b5a3fff619dc7e48b6b1bedc2f30ec43033ba7af32f936c10839e81b9217"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:3d370ff652323c5307d9c8e4c62efd1956fb08051b0e9210212bc51168b4ff56"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:b076da1ed19dc37788f6a934c60adf97bd02c7eea461b73730513921a85d4235"},
+    {file = "regex-2023.8.8-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e9941a4ada58f6218694f382e43fdd256e97615db9da135e77359da257a7168b"},
+    {file = "regex-2023.8.8-cp36-cp36m-win32.whl", hash = "sha256:a8c65c17aed7e15a0c824cdc63a6b104dfc530f6fa8cb6ac51c437af52b481c7"},
+    {file = "regex-2023.8.8-cp36-cp36m-win_amd64.whl", hash = "sha256:aadf28046e77a72f30dcc1ab185639e8de7f4104b8cb5c6dfa5d8ed860e57236"},
+    {file = "regex-2023.8.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:423adfa872b4908843ac3e7a30f957f5d5282944b81ca0a3b8a7ccbbfaa06103"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ae594c66f4a7e1ea67232a0846649a7c94c188d6c071ac0210c3e86a5f92109"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e51c80c168074faa793685656c38eb7a06cbad7774c8cbc3ea05552d615393d8"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:09b7f4c66aa9d1522b06e31a54f15581c37286237208df1345108fcf4e050c18"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e73e5243af12d9cd6a9d6a45a43570dbe2e5b1cdfc862f5ae2b031e44dd95a8"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:941460db8fe3bd613db52f05259c9336f5a47ccae7d7def44cc277184030a116"},
+    {file = "regex-2023.8.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f0ccf3e01afeb412a1a9993049cb160d0352dba635bbca7762b2dc722aa5742a"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:2e9216e0d2cdce7dbc9be48cb3eacb962740a09b011a116fd7af8c832ab116ca"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:5cd9cd7170459b9223c5e592ac036e0704bee765706445c353d96f2890e816c8"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:4873ef92e03a4309b3ccd8281454801b291b689f6ad45ef8c3658b6fa761d7ac"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:239c3c2a339d3b3ddd51c2daef10874410917cd2b998f043c13e2084cb191684"},
+    {file = "regex-2023.8.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:1005c60ed7037be0d9dea1f9c53cc42f836188227366370867222bda4c3c6bd7"},
+    {file = "regex-2023.8.8-cp37-cp37m-win32.whl", hash = "sha256:e6bd1e9b95bc5614a7a9c9c44fde9539cba1c823b43a9f7bc11266446dd568e3"},
+    {file = "regex-2023.8.8-cp37-cp37m-win_amd64.whl", hash = "sha256:9a96edd79661e93327cfeac4edec72a4046e14550a1d22aa0dd2e3ca52aec921"},
+    {file = "regex-2023.8.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f2181c20ef18747d5f4a7ea513e09ea03bdd50884a11ce46066bb90fe4213675"},
+    {file = "regex-2023.8.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a2ad5add903eb7cdde2b7c64aaca405f3957ab34f16594d2b78d53b8b1a6a7d6"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9233ac249b354c54146e392e8a451e465dd2d967fc773690811d3a8c240ac601"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:920974009fb37b20d32afcdf0227a2e707eb83fe418713f7a8b7de038b870d0b"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2b6c5dfe0929b6c23dde9624483380b170b6e34ed79054ad131b20203a1a63"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96979d753b1dc3b2169003e1854dc67bfc86edf93c01e84757927f810b8c3c93"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ae54a338191e1356253e7883d9d19f8679b6143703086245fb14d1f20196be9"},
+    {file = "regex-2023.8.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2162ae2eb8b079622176a81b65d486ba50b888271302190870b8cc488587d280"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:c884d1a59e69e03b93cf0dfee8794c63d7de0ee8f7ffb76e5f75be8131b6400a"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cf9273e96f3ee2ac89ffcb17627a78f78e7516b08f94dc435844ae72576a276e"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:83215147121e15d5f3a45d99abeed9cf1fe16869d5c233b08c56cdf75f43a504"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:3f7454aa427b8ab9101f3787eb178057c5250478e39b99540cfc2b889c7d0586"},
+    {file = "regex-2023.8.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f0640913d2c1044d97e30d7c41728195fc37e54d190c5385eacb52115127b882"},
+    {file = "regex-2023.8.8-cp38-cp38-win32.whl", hash = "sha256:0c59122ceccb905a941fb23b087b8eafc5290bf983ebcb14d2301febcbe199c7"},
+    {file = "regex-2023.8.8-cp38-cp38-win_amd64.whl", hash = "sha256:c12f6f67495ea05c3d542d119d270007090bad5b843f642d418eb601ec0fa7be"},
+    {file = "regex-2023.8.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:82cd0a69cd28f6cc3789cc6adeb1027f79526b1ab50b1f6062bbc3a0ccb2dbc3"},
+    {file = "regex-2023.8.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bb34d1605f96a245fc39790a117ac1bac8de84ab7691637b26ab2c5efb8f228c"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:987b9ac04d0b38ef4f89fbc035e84a7efad9cdd5f1e29024f9289182c8d99e09"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9dd6082f4e2aec9b6a0927202c85bc1b09dcab113f97265127c1dc20e2e32495"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7eb95fe8222932c10d4436e7a6f7c99991e3fdd9f36c949eff16a69246dee2dc"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7098c524ba9f20717a56a8d551d2ed491ea89cbf37e540759ed3b776a4f8d6eb"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b694430b3f00eb02c594ff5a16db30e054c1b9589a043fe9174584c6efa8033"},
+    {file = "regex-2023.8.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b2aeab3895d778155054abea5238d0eb9a72e9242bd4b43f42fd911ef9a13470"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:988631b9d78b546e284478c2ec15c8a85960e262e247b35ca5eaf7ee22f6050a"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:67ecd894e56a0c6108ec5ab1d8fa8418ec0cff45844a855966b875d1039a2e34"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:14898830f0a0eb67cae2bbbc787c1a7d6e34ecc06fbd39d3af5fe29a4468e2c9"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:f2200e00b62568cfd920127782c61bc1c546062a879cdc741cfcc6976668dfcf"},
+    {file = "regex-2023.8.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9691a549c19c22d26a4f3b948071e93517bdf86e41b81d8c6ac8a964bb71e5a6"},
+    {file = "regex-2023.8.8-cp39-cp39-win32.whl", hash = "sha256:6ab2ed84bf0137927846b37e882745a827458689eb969028af8032b1b3dac78e"},
+    {file = "regex-2023.8.8-cp39-cp39-win_amd64.whl", hash = "sha256:5543c055d8ec7801901e1193a51570643d6a6ab8751b1f7dd9af71af467538bb"},
+    {file = "regex-2023.8.8.tar.gz", hash = "sha256:fcbdc5f2b0f1cd0f6a56cdb46fe41d2cce1e644e3b68832f3eeebc5fb0f7712e"},
 ]
 
 [[package]]
@@ -1308,19 +1308,19 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "68.1.2"
+version = "68.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-68.1.2-py3-none-any.whl", hash = "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"},
-    {file = "setuptools-68.1.2.tar.gz", hash = "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d"},
+    {file = "setuptools-68.2.0-py3-none-any.whl", hash = "sha256:af3d5949030c3f493f550876b2fd1dd5ec66689c4ee5d5344f009746f71fd5a8"},
+    {file = "setuptools-68.2.0.tar.gz", hash = "sha256:00478ca80aeebeecb2f288d3206b0de568df5cd2b8fada1209843cc9a8d88a48"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5,<=7.1.2)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "helply"
-version = "0.3.0"
+version = "0.3.2"
 description = "A library that simplifies 'help' command creation for application commands in your discord bot."
 authors = ["DLCHAMP <contact@dlchamp.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "helply"
-version = "0.2.1"
+version = "0.3.0"
 description = "A library that simplifies 'help' command creation for application commands in your discord bot."
 authors = ["DLCHAMP <contact@dlchamp.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "helply"
-version = "0.3.2"
+version = "0.3.3"
 description = "A library that simplifies 'help' command creation for application commands in your discord bot."
 authors = ["DLCHAMP <contact@dlchamp.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,13 @@ python-dotenv = "^1.0.0"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.5.1"
-mdx-truly-sane-lists = "^1.3"
 mkdocs-markdownextradata-plugin = "^0.2.5"
 mkdocstrings = {extras = ["python"], version = "^0.22.0"}
 mkdocs-material = "^9.1.21"
 mkdocs-autorefs = "^0.4.1"
 mkdocs-gen-files = "^0.5.0"
 mkdocs-literate-nav = "^0.6.0"
+mkdocs-minify-plugin = "^0.7.1"
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ combine-as-imports = true
 [tool.pyright]
 typeCheckingMode = "strict"
 pythonVersion = "3.8"
-ignore = ["tests/", "examples/", "docs/"]
+ignore = ["tests/", "examples/", "docs/", "site/"]
 
 [tool.ruff]
 line-length = 100

--- a/src/helply/__init__.py
+++ b/src/helply/__init__.py
@@ -9,7 +9,7 @@ in your disnake bot.
 """
 
 
-__version__ = "0.3.0"
+__version__ = "0.3.2"
 
 
 from .helply import Helply

--- a/src/helply/__init__.py
+++ b/src/helply/__init__.py
@@ -9,7 +9,7 @@ in your disnake bot.
 """
 
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 
 from .helply import Helply

--- a/src/helply/__init__.py
+++ b/src/helply/__init__.py
@@ -9,7 +9,7 @@ in your disnake bot.
 """
 
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 
 from .helply import Helply

--- a/src/helply/helply.py
+++ b/src/helply/helply.py
@@ -403,7 +403,7 @@ class Helply:
                     self._app_commands[user_command.id] = user_command
 
     @overload
-    def get_all_commands(
+    def get_commands(
         self,
         guild_id: Optional[int] = None,
         *,
@@ -416,7 +416,7 @@ class Helply:
         ...
 
     @overload
-    def get_all_commands(
+    def get_commands(
         self,
         guild_id: Optional[int] = None,
         *,
@@ -428,7 +428,7 @@ class Helply:
     ) -> List[AppCommand]:
         ...
 
-    def get_all_commands(
+    def get_commands(
         self,
         guild_id: Optional[int] = None,
         *,
@@ -698,7 +698,7 @@ class Helply:
                 Should not specify `guild_id` or `permissions` if setting this to True
 
         Example:
-        ```py
+        ```python
         @some_command.autocomplete('category')
         async def some_command_group_autocomplete(
             inter: disnake.ApplicationCommandInteraction, string: str

--- a/src/helply/helply.py
+++ b/src/helply/helply.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union, overload
 
 import disnake
 import disnake.app_commands
@@ -9,10 +9,15 @@ from .types import (
     AppCommandType,
     Argument,
     CommandChecks,
+    LocalizedAppCommand,
     MessageCommand,
     SlashCommand,
     UserCommand,
 )
+
+if TYPE_CHECKING:
+    from .types.abc_ import AppCommandBase
+
 
 Bot = Union[
     commands.Bot,
@@ -165,7 +170,7 @@ class Helply:
                         description_localizations=command.description_localizations,
                         args=args,
                         checks=checks,
-                        type=AppCommandType.slash,
+                        type=AppCommandType.SLASH,
                         dm_permission=dm_permissions,
                         nsfw=nsfw,
                         category=category,
@@ -268,7 +273,7 @@ class Helply:
                 description_localizations=command.description_localizations,
                 args=args,
                 checks=checks,
-                type=AppCommandType.slash,
+                type=AppCommandType.SLASH,
                 dm_permission=command.dm_permission,
                 nsfw=command.nsfw,
                 guild_id=command.guild_id,
@@ -306,7 +311,7 @@ class Helply:
             description=desc,
             name_localizations=command.name_localizations,
             checks=checks,
-            type=AppCommandType.message,
+            type=AppCommandType.MESSAGE,
             dm_permission=command.dm_permission,
             nsfw=command.nsfw,
             guild_id=command.guild_id,
@@ -342,7 +347,7 @@ class Helply:
             description=desc,
             name_localizations=command.name_localizations,
             checks=checks,
-            type=AppCommandType.user,
+            type=AppCommandType.USER,
             dm_permission=command.dm_permission,
             nsfw=command.nsfw,
             guild_id=command.guild_id,
@@ -363,7 +368,7 @@ class Helply:
         Returns
         -------
         str
-            `Cog's` name or str value set in `.extras['category']` or 'None'
+            Command's cog_name or value of extras['catetory'], else "None"
 
         """
         name = invokable.cog_name or invokable.extras.get("category")
@@ -397,14 +402,42 @@ class Helply:
                 if user_command:
                     self._app_commands[user_command.id] = user_command
 
+    @overload
     def get_all_commands(
         self,
         guild_id: Optional[int] = None,
         *,
+        category: Optional[str] = None,
         permissions: Optional[disnake.Permissions] = None,
         include_nsfw: bool = True,
         dm_only: bool = False,
+        locale: disnake.Locale,
+    ) -> List[LocalizedAppCommand]:
+        ...
+
+    @overload
+    def get_all_commands(
+        self,
+        guild_id: Optional[int] = None,
+        *,
+        category: Optional[str] = None,
+        permissions: Optional[disnake.Permissions] = None,
+        include_nsfw: bool = True,
+        dm_only: bool = False,
+        locale: None = None,
     ) -> List[AppCommand]:
+        ...
+
+    def get_all_commands(
+        self,
+        guild_id: Optional[int] = None,
+        *,
+        category: Optional[str] = None,
+        permissions: Optional[disnake.Permissions] = None,
+        include_nsfw: bool = True,
+        dm_only: bool = False,
+        locale: Optional[disnake.Locale] = None,
+    ) -> Union[List[AppCommand], List[LocalizedAppCommand]]:
         """Retrieve a filtered list of AppCommand based on specified criteria.
 
         By default, this method should return all registered commands. Specify filters
@@ -415,6 +448,8 @@ class Helply:
         guild_id : Optional[int]
             Filter commands registered to the specified guild_id.  If not specified,
             all commands may be returned.
+        category: Optional[str]
+            Filter commands by only a specified category
         permissions: Optional[disnake.Permissions]
             Filter commands that do not exceed permissions. If not specified,
             commands will not be filtered by permissions.
@@ -426,19 +461,26 @@ class Helply:
             Whether or not to include only commands with direct message enabled.
             !!! Note
                 Should not specify `guild_id` or `permissions` if setting this to True
+        locale: Optional[disnake.Locale]
+            Specify locale to get localized commands and arguments.
+
 
         Returns
         -------
-        List[AppCommand]
-            Resulting list of AppCommands after filters have been applied.
+        Union[List[AppCommand], List[LocalizedAppCommand]]
+            Resulting list of `AppCommand` or `LocalizedAppCommand`, if locale specified,
+            after filters have been applied.
         """
 
         if not self._app_commands:
             self._walk_app_commands()
 
-        commands: List[AppCommand] = []
+        commands: List[AppCommandBase] = []
 
         for command in self._app_commands.values():
+            if category and command.category != category:
+                continue
+
             if guild_id and command.guild_id and command.guild_id != guild_id:
                 continue
 
@@ -458,19 +500,77 @@ class Helply:
             if not include_nsfw and command.nsfw:
                 continue
 
+            if locale:
+                command = command.localize(locale)
+
             commands.append(command)
 
-        return commands
+        return commands  # type: ignore - I don't know how to fix this yet ;)
+
+    @overload
+    def get_command(self, id: int, locale: None = None) -> Optional[AppCommand]:
+        ...
+
+    @overload
+    def get_command(self, id: int, locale: disnake.Locale) -> Optional[LocalizedAppCommand]:
+        ...
+
+    def get_command(
+        self, id: int, locale: Optional[disnake.Locale] = None
+    ) -> Optional[Union[AppCommand, LocalizedAppCommand]]:
+        """Get a command by its ID
+
+        Parameters
+        ----------
+        id: int
+            ID of the AppCommand
+        locale: Optional[disnake.Locale]
+            Specify locale to get a localized command instead.
+
+        Returns
+        --------
+        Optional[Union[AppCommand, LocalizedAppCommand]]
+            The retrieved `AppCommand` or `LocalizedAppCommand` if locale specified.
+        """
+        command = self._app_commands.get(id)
+        if locale and command:
+            command = command.localize(locale)
+
+        return command
+
+    @overload
+    def get_command_named(
+        self,
+        name: str,
+        locale: None = None,
+        cmd_type: Optional[AppCommandType] = None,
+    ) -> Optional[AppCommand]:
+        ...
+
+    @overload
+    def get_command_named(
+        self,
+        name: str,
+        locale: disnake.Locale,
+        cmd_type: Optional[AppCommandType] = None,
+    ) -> Optional[LocalizedAppCommand]:
+        ...
 
     def get_command_named(
-        self, name: str, cmd_type: Optional[AppCommandType] = None
-    ) -> Optional[AppCommand]:
-        """Get a command by its non-localized name
+        self,
+        name: str,
+        locale: Optional[disnake.Locale] = None,
+        cmd_type: Optional[AppCommandType] = None,
+    ) -> Optional[Union[AppCommand, LocalizedAppCommand]]:
+        """Get a command by its name. if locale is provided, the provided name should
+        match the localized name.
 
         Parameters
         ----------
         name : str
             Name of the ApplicationCommand.
+        locale: Optional[disnake.Locale]
+            Specify locale to get a localized command and arguments.
         cmd_type: Optional[AppCommandType]
             Specify the type of command to be returned. If not specified, the first matching
             command will be returned regardless of its type.
@@ -478,38 +578,54 @@ class Helply:
 
         Returns
         -------
-        Optional[AppCommand]
+        Optional[Union[AppCommand, LocalizedAppCommand]]
             The command that matches the provided name, if found.
         """
         for command in self._app_commands.values():
+            if locale:
+                command = command.localize(locale)
+
             if command.name == name and (cmd_type is None or command.type is cmd_type):
                 return command
 
-    def get_command(self, id: int) -> Optional[AppCommand]:
-        """Get a command by its ID
-
-        Parameters
-        ----------
-        id: int
-            ID of the AppCommand
-
-        Returns
-        --------
-        Optional[AppCommand]
-            The retrieved AppCommand or None of not found.
-        """
-        return self._app_commands.get(id)
-
+    @overload
     def get_commands_by_category(
         self,
         category: str,
         *,
+        locale: disnake.Locale,
+        guild_id: Optional[int] = None,
+        permissions: Optional[disnake.Permissions] = None,
+        include_nsfw: bool = True,
+        dm_only: bool = False,
+    ) -> List[LocalizedAppCommand]:
+        ...
+
+    @overload
+    def get_commands_by_category(
+        self,
+        category: str,
+        *,
+        locale: None = None,
         guild_id: Optional[int] = None,
         permissions: Optional[disnake.Permissions] = None,
         include_nsfw: bool = True,
         dm_only: bool = False,
     ) -> List[AppCommand]:
-        """Retrieve a filtered list of AppCommand based on specified criteria within a category.
+        ...
+
+    def get_commands_by_category(
+        self,
+        category: str,
+        *,
+        locale: Optional[disnake.Locale] = None,
+        guild_id: Optional[int] = None,
+        permissions: Optional[disnake.Permissions] = None,
+        include_nsfw: bool = True,
+        dm_only: bool = False,
+    ) -> Union[List[AppCommand], List[LocalizedAppCommand]]:
+        """Retrieve a list of `AppCommand` or `LocalizedAppCommand`, if locale specified
+        within the specified category.
 
         By default, this method should return all registered commands within a category.
         Specify filters to narrow down the output results.
@@ -518,6 +634,8 @@ class Helply:
         ----------
         category: str
             Category for which commands are in.
+        locale: Optional[disnake.Locale]
+            Include locale to get localized commands.
         guild_id : Optional[int]
             Filter commands registered to the specified guild_id.  If not specified,
             all commands may be returned.
@@ -535,17 +653,19 @@ class Helply:
 
         Returns
         --------
-        List[AppCommand]
-            A list of commands within the specified group name.
+        Union[List[AppCommand], List[LocalizedAppCommand]]
+            A list of commands within the specified category name.
+            If locale provided, a list of LocalizedAppCommand will be returned instead
 
         """
-        commands = self.get_all_commands(
+        return self.get_all_commands(
             guild_id,
+            category=category,
             permissions=permissions,
             include_nsfw=include_nsfw,
             dm_only=dm_only,
+            locale=locale,
         )
-        return [command for command in commands if command.category == category]
 
     def get_categories(
         self,
@@ -555,10 +675,10 @@ class Helply:
         include_nsfw: bool = True,
         dm_only: bool = False,
     ) -> List[str]:
-        """Return a unique list of command group names.
+        """Return a unique list of command categories.
 
         Useful if you wish to have an autocomplete for users to select from available
-        command groups
+        command categories.
 
         Parameters
         ----------
@@ -606,20 +726,69 @@ class Helply:
 
         return categories
 
-    def get_dm_only_commands(self, *, include_nsfw: bool = False) -> List[AppCommand]:
+    @overload
+    def get_dm_only_commands(
+        self,
+        *,
+        include_nsfw: bool = False,
+        locale: None = None,
+    ) -> List[AppCommand]:
+        ...
+
+    @overload
+    def get_dm_only_commands(
+        self,
+        *,
+        include_nsfw: bool = False,
+        locale: disnake.Locale,
+    ) -> List[LocalizedAppCommand]:
+        ...
+
+    def get_dm_only_commands(
+        self,
+        *,
+        include_nsfw: bool = False,
+        locale: Optional[disnake.Locale] = None,
+    ) -> Union[List[AppCommand], List[LocalizedAppCommand]]:
         """A shortcut method for returning only commands with direct message enabled.
 
         Parameters
         ----------
         include_nsfw: bool
             Whether or not to include NSFW commands.
+        locale: Optional[disnake.Locale]
+            Include local to get localized commands.
+
 
         Returns
         -------
-        List[AppCommand]
-            A list of commands with `.dm_permissions` set to True
+        Union[List[AppCommand], List[LocalizedAppCommand]]]
+            A list of `AppCommand`, or `LocalizedAppCommand` if locale specified, where
+            dm_permission = True
         """
-        return self.get_all_commands(dm_only=True, include_nsfw=include_nsfw)
+        return self.get_all_commands(dm_only=True, locale=locale, include_nsfw=include_nsfw)
+
+    @overload
+    def get_guild_commands(
+        self,
+        guild_id: int,
+        *,
+        include_nsfw: bool = False,
+        permissions: Optional[disnake.Permissions] = None,
+        locale: None = None,
+    ) -> List[AppCommand]:
+        ...
+
+    @overload
+    def get_guild_commands(
+        self,
+        guild_id: int,
+        *,
+        include_nsfw: bool = False,
+        permissions: Optional[disnake.Permissions] = None,
+        locale: disnake.Locale,
+    ) -> List[LocalizedAppCommand]:
+        ...
 
     def get_guild_commands(
         self,
@@ -627,8 +796,9 @@ class Helply:
         *,
         include_nsfw: bool = False,
         permissions: Optional[disnake.Permissions] = None,
-    ) -> List[AppCommand]:
-        """This method returns global and guild-specific commands available to a guild.
+        locale: Optional[disnake.Locale] = None,
+    ) -> Union[List[AppCommand], List[LocalizedAppCommand]]:
+        """A shortcut method to returning global and guild-specific commands.
 
         !!! Note
             Including `permissions` will restrict the command list to prevent commands hidden by
@@ -642,8 +812,18 @@ class Helply:
         permissions: Optional[disnake.Permissions]
             Set the permission limit of the resulting commands.  Any commands that exceed specified
             permissions will be omitted
+        locale: Optional[disnake.Locale]
+            Specify locale to get localized commands and arguments.
+
+        Returns
+        -------
+        Union[List[AppCommand], List[LocalizedAppCommand]]
+            A list of `AppCommand`, or `LocalizedAppCommand` if locale specified, where
+            guild_id is not specified (global) or guild_id matches the specified guild_id.
         """
-        return self.get_all_commands(guild_id, include_nsfw=include_nsfw, permissions=permissions)
+        return self.get_all_commands(
+            guild_id, locale=locale, include_nsfw=include_nsfw, permissions=permissions
+        )
 
     @staticmethod
     def roles_from_checks(checks: CommandChecks, guild: disnake.Guild) -> List[disnake.Role]:

--- a/src/helply/helply.py
+++ b/src/helply/helply.py
@@ -17,6 +17,12 @@ from .types import (
 Bot = Union[
     commands.Bot,
     commands.InteractionBot,
+    commands.AutoShardedBot,
+    commands.AutoShardedInteractionBot,
+]
+
+APIApplicationCommand = Union[
+    disnake.APIMessageCommand, disnake.APISlashCommand, disnake.APIUserCommand
 ]
 
 
@@ -36,6 +42,8 @@ class Helply:
 
         if commands_to_ignore is not None:
             self.commands_to_ignore: set[str] = set(commands_to_ignore)
+        else:
+            self.commands_to_ignore = set()
 
         self._app_commands: Dict[int, AppCommand] = {}
 
@@ -63,7 +71,13 @@ class Helply:
                 continue
 
             args.append(
-                Argument(name=option.name, required=option.required, description=option.description)
+                Argument(
+                    name=option.name,
+                    name_localizations=option.name_localizations,
+                    description=option.description,
+                    description_localizations=option.description_localizations,
+                    required=option.required,
+                )
             )
 
         return args
@@ -147,6 +161,8 @@ class Helply:
                         id=command_id,
                         name=name,
                         description=desc,
+                        name_localizations=command.name_localizations,
+                        description_localizations=command.description_localizations,
                         args=args,
                         checks=checks,
                         type=AppCommandType.slash,
@@ -248,6 +264,8 @@ class Helply:
                 id=command.id,
                 name=command.name,
                 description=desc,
+                name_localizations=command.name_localizations,
+                description_localizations=command.description_localizations,
                 args=args,
                 checks=checks,
                 type=AppCommandType.slash,
@@ -285,13 +303,14 @@ class Helply:
         return MessageCommand(
             id=command.id,
             name=command.name,
+            description=desc,
+            name_localizations=command.name_localizations,
             checks=checks,
             type=AppCommandType.message,
-            description=desc,
             dm_permission=command.dm_permission,
             nsfw=command.nsfw,
             guild_id=command.guild_id,
-            default_member_permissions=command.default_member_permissions,
+            default_member_permissions=invokable.default_member_permissions,
             category=category,
         )
 
@@ -320,13 +339,14 @@ class Helply:
         return UserCommand(
             id=command.id,
             name=command.name,
-            type=AppCommandType.user,
-            checks=checks,
             description=desc,
+            name_localizations=command.name_localizations,
+            checks=checks,
+            type=AppCommandType.user,
             dm_permission=command.dm_permission,
             nsfw=command.nsfw,
             guild_id=command.guild_id,
-            default_member_permissions=command.default_member_permissions,
+            default_member_permissions=invokable.default_member_permissions,
             category=category,
         )
 
@@ -445,7 +465,7 @@ class Helply:
     def get_command_named(
         self, name: str, cmd_type: Optional[AppCommandType] = None
     ) -> Optional[AppCommand]:
-        """Get a command by its name.
+        """Get a command by its non-localized name
 
         Parameters
         ----------

--- a/src/helply/types/__init__.py
+++ b/src/helply/types/__init__.py
@@ -1,3 +1,4 @@
+from .base import *
 from .checks import *
-from .commands import *
 from .enums import *
+from .localized import *

--- a/src/helply/types/__init__.py
+++ b/src/helply/types/__init__.py
@@ -1,4 +1,4 @@
-from .base import *
 from .checks import *
+from .commands import *
 from .enums import *
 from .localized import *

--- a/src/helply/types/abc_.py
+++ b/src/helply/types/abc_.py
@@ -18,9 +18,9 @@ class ArgumentBase(ABC):
     Attributes
     ----------
     name: str
-        Argument's non-localized name
+        Argument's name
     description: str
-        Argument's non-localized description
+        Argument's description
     required: bool
         Whether or not the argument is required
     """
@@ -55,7 +55,7 @@ class AppCommandBase(ABC):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
-    guild_id : int, optional
+    guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Permissions, optional
         Default member permissions required to use this command.

--- a/src/helply/types/abc_.py
+++ b/src/helply/types/abc_.py
@@ -13,7 +13,7 @@ __all__ = (
 
 
 class ArgumentBase(ABC):
-    """Base class for slash command arguments
+    """Base class for Argument.
 
     Attributes
     ----------
@@ -32,7 +32,7 @@ class ArgumentBase(ABC):
 
 
 class AppCommandBase(ABC):
-    """Base class for all AppCommand and LocalizedAppCommand
+    """Base class for AppCommand and LocalizedAppCommand
 
     AppCommands are classes that include various attributes from both
     `.ApplicationCommand` and `.InvokableApplicationCommand`
@@ -42,13 +42,9 @@ class AppCommandBase(ABC):
     id : int
         The command's unique identifier.
     name: str
-        Command's non-localized name
+        Command's name
     description: str
-        Command's non-localized description
-    name_localizations: disnake.LocalizationValue
-        Contains localizations for the command's name. (*New in version 0.3.0*)
-    description_localizations: Optional[disnake.LocalizationValue]
-        Contains localizations for the command's description. (*New in version 0.3.0*)
+        Command's description
     checks : CommandChecks
         The command's permission and role requirements.
     type: AppCommandType
@@ -93,6 +89,6 @@ class AppCommandBase(ABC):
 
     @property
     def mention(self) -> str:
-        if self.type is AppCommandType.slash:
+        if self.type is AppCommandType.SLASH:
             return f"</{self.name}:{self.id}>"
         return f"**{self.name}**"

--- a/src/helply/types/abc_.py
+++ b/src/helply/types/abc_.py
@@ -1,0 +1,98 @@
+from abc import ABC
+from typing import Optional
+
+from disnake import Permissions
+
+from .checks import CommandChecks
+from .enums import AppCommandType
+
+__all__ = (
+    "ArgumentBase",
+    "AppCommandBase",
+)
+
+
+class ArgumentBase(ABC):
+    """Base class for slash command arguments
+
+    Attributes
+    ----------
+    name: str
+        Argument's non-localized name
+    description: str
+        Argument's non-localized description
+    required: bool
+        Whether or not the argument is required
+    """
+
+    def __init__(self, name: str, description: str, required: bool) -> None:
+        self.name = name
+        self.description = description
+        self.required = required
+
+
+class AppCommandBase(ABC):
+    """Base class for all AppCommand and LocalizedAppCommand
+
+    AppCommands are classes that include various attributes from both
+    `.ApplicationCommand` and `.InvokableApplicationCommand`
+
+    Attributes
+    ----------
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's non-localized name
+    description: str
+        Command's non-localized description
+    name_localizations: disnake.LocalizationValue
+        Contains localizations for the command's name. (*New in version 0.3.0*)
+    description_localizations: Optional[disnake.LocalizationValue]
+        Contains localizations for the command's description. (*New in version 0.3.0*)
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : int, optional
+        The ID of the guild where the command is available.
+    default_member_permissions : Permissions, optional
+        Default member permissions required to use this command.
+    mention : str
+        Get the command as a mentionable if slash command, else returns bolded name.
+    """
+
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        description: str,
+        checks: CommandChecks,
+        type: AppCommandType,
+        category: str,
+        dm_permission: bool,
+        nsfw: bool,
+        guild_id: Optional[int] = None,
+        default_member_permissions: Optional[Permissions] = None,
+    ) -> None:
+        self.id = id
+        self.name = name
+        self.description = description
+        self.checks = checks
+        self.type = type
+        self.category = category
+        self.dm_permission = dm_permission
+        self.nsfw = nsfw
+        self.guild_id = guild_id
+        self.default_member_permissions = default_member_permissions
+
+    @property
+    def mention(self) -> str:
+        if self.type is AppCommandType.slash:
+            return f"</{self.name}:{self.id}>"
+        return f"**{self.name}**"

--- a/src/helply/types/commands.py
+++ b/src/helply/types/commands.py
@@ -44,7 +44,7 @@ class Argument(ArgumentBase):
         Returns localized or non-localized name. (*New in version 0.3.0*)
     get_localized_description(locale: disnake.Locale)
         Returns localized or non-localized description. (*New in version 0.3.0*)
-    localized(locale: disnake.Locale)
+    localize(locale: disnake.Locale)
         Returns a LocalizedArgument
     """
 
@@ -101,7 +101,7 @@ class Argument(ArgumentBase):
 
         return self.description_localizations.data.get(str(locale), self.description)
 
-    def localized(self, locale: Locale) -> LocalizedArgument:
+    def localize(self, locale: Locale) -> LocalizedArgument:
         """Returns a LocalizedArgument instance from this Argument.
 
         LocalizedArument instances are just simplified Arguments with localized attribute values
@@ -139,8 +139,6 @@ class AppCommand(AppCommandBase):
         Command's non-localized description
     name_localizations: disnake.LocalizationValue
         Contains localizations for the command's name. (*New in version 0.3.0*)
-    description_localizations: Optional[disnake.LocalizationValue]
-        Contains localizations for the command's description. (*New in version 0.3.0*)
     checks : CommandChecks
         The command's permission and role requirements.
     type: AppCommandType
@@ -164,7 +162,7 @@ class AppCommand(AppCommandBase):
         Returns localized or non-localized name. (*New in version 0.3.0*)
     get_localized_description(locale: disnake.Locale)
         Returns localized or non-localized description. (*New in version 0.3.0*)
-    localized(locale: disnake.Locale)
+    localize(locale: disnake.Locale)
         Returns a LocalizedAppcommand, or sub-variant
     """
 
@@ -198,12 +196,6 @@ class AppCommand(AppCommandBase):
 
         self.name_localizations: LocalizationValue = name_localizations
         self.description_localizations: Optional[LocalizationValue] = description_localizations
-
-    @property
-    def mention(self) -> str:
-        if isinstance(self, SlashCommand):
-            return f"</{self.name}:{self.id}>"
-        return f"**{self.name}**"
 
     def get_localized_name(self, locale: Locale) -> str:
         """Returns localized or non-localized name. specified by the provided locale.
@@ -250,7 +242,7 @@ class AppCommand(AppCommandBase):
         description = self.get_localized_description(locale)
 
         if isinstance(self, SlashCommand):
-            args = [a.localized(locale) for a in self.args]
+            args = [a.localize(locale) for a in self.args]
             return LocalizedSlashCommand(
                 id=self.id,
                 name=name,
@@ -298,7 +290,44 @@ class SlashCommand(AppCommand):
 
     Attributes
     ----------
-    args: List[Argument]"""
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's non-localized name
+    description: str
+        Command's non-localized description
+    name_localizations: disnake.LocalizationValue
+        Contains localizations for the command's name. (*New in version 0.3.0*)
+    description_localizations: disnake.LocalizationValue
+        Contains localizations for the command's description. (*New in version 0.3.0*)
+    args: List[Argument]
+        Contains the command's arguments
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : Optional[int]
+        The ID of the guild where the command is available.
+    default_member_permissions : Permissions, optional
+        Default member permissions required to use this command.
+    mention : str
+        Get the command as a mentionable if slash command, else returns bolded name.
+
+    Methods
+    -------
+    get_localized_name(locale: Optional[Locale])
+        Returns localized or non-localized name. (*New in version 0.3.0*)
+    get_localized_description(locale: disnake.Locale)
+        Returns localized or non-localized description. (*New in version 0.3.0*)
+    localize(locale: disnake.Locale)
+        Returns a LocalizedSlashCommand
+    """
 
     def __init__(
         self,
@@ -335,7 +364,45 @@ class SlashCommand(AppCommand):
 
 
 class UserCommand(AppCommand):
-    """Represents a user command type AppCommand"""
+    """Represents a user command type AppCommand
+
+
+    Attributes
+    ----------
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's non-localized name
+    description: str
+        Command's non-localized description
+    name_localizations: disnake.LocalizationValue
+        Contains localizations for the command's name. (*New in version 0.3.0*)
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : Optional[int]
+        The ID of the guild where the command is available.
+    default_member_permissions : Permissions, optional
+        Default member permissions required to use this command.
+    mention : str
+        Get the command as a mentionable if slash command, else returns bolded name.
+
+    Methods
+    -------
+    get_localized_name(locale: Optional[Locale])
+        Returns localized or non-localized name. (*New in version 0.3.0*)
+    get_localized_description(locale: disnake.Locale)
+        Returns localized or non-localized description. (*New in version 0.3.0*)
+    localize(locale: disnake.Locale)
+        Returns a LocalizedAppcommand, or sub-variant
+    """
 
     def __init__(
         self,
@@ -367,7 +434,44 @@ class UserCommand(AppCommand):
 
 
 class MessageCommand(AppCommand):
-    """Represents a message command type AppCommand"""
+    """Represents a message command type AppCommand
+
+    Attributes
+    ----------
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's non-localized name
+    description: str
+        Command's non-localized description
+    name_localizations: disnake.LocalizationValue
+        Contains localizations for the command's name. (*New in version 0.3.0*)
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : Optional[int]
+        The ID of the guild where the command is available.
+    default_member_permissions : Permissions, optional
+        Default member permissions required to use this command.
+    mention : str
+        Get the command as a mentionable if slash command, else returns bolded name.
+
+    Methods
+    -------
+    get_localized_name(locale: Optional[Locale])
+        Returns localized or non-localized name. (*New in version 0.3.0*)
+    get_localized_description(locale: disnake.Locale)
+        Returns localized or non-localized description. (*New in version 0.3.0*)
+    localize(locale: disnake.Locale)
+        Returns a LocalizedAppcommand, or sub-variant
+    """
 
     def __init__(
         self,

--- a/src/helply/types/commands.py
+++ b/src/helply/types/commands.py
@@ -1,7 +1,7 @@
 import dataclasses
 from typing import TYPE_CHECKING, List, Optional
 
-from disnake import Permissions
+from disnake import Locale, LocalizationValue, Permissions
 
 from .checks import CommandChecks
 
@@ -24,27 +24,70 @@ class Argument:
 
     Attributes
     ----------
-    name : str
-        Name of the argument.
-    required : bool
-        Indicate if the argument is required.
-    description : str
-        A brief description of the argument.
+    name: str
+        Argument's non-localized name
+    description: str
+        Argument's non-localized description
+    required: bool
+        Whether or not the argument is required.
+    name_localizations: disnake.LocalizationValue
+        Contains localizations for the argument's name
+    description_localizations: disnake.LocalizationValue
+        Contains localizations for the argument's description.
+
+    Methods
+    -------
+    get_localized_name(locale: disnake.Locale)
+        Returns localized or non-localized name.
+    get_localized_description(locale: disnake.Locale)
+        Returns localized or non-localized description.
     """
 
     name: str
-    required: bool
+    name_localizations: LocalizationValue
     description: str
+    description_localizations: LocalizationValue
+    required: bool
 
-    def __str__(self) -> str:
-        """Return the argument as a string.
+    def get_localized_name(self, locale: Locale) -> str:
+        """Returns localized or non-localized name. specified by the provided locale.
 
-        Required arguments will have `[]` wrapped around their name,
-        while optional arguments will be wrapped with `()`.
+        If not available, returns the non-localized name instead.
+
+        Parameters
+        ----------
+        locale: disnake.Local
+            The interaction locale
+
+        Returns
+        -------
+        str
+            The localized or non-localized name.
         """
-        if self.required:
-            return f"[{self.name}]"
-        return f"({self.name})"
+        if not self.name_localizations or not self.name_localizations.data:
+            return self.name
+
+        return self.name_localizations.data.get(str(locale), self.name)
+
+    def get_localized_description(self, locale: Locale) -> str:
+        """Returns localized or non-localized description. specified by the provided locale.
+
+        If not available, returns the non-localized description instead.
+
+        Parameters
+        ----------
+        locale: disnake.Local
+            The interaction locale
+
+        Returns
+        -------
+        str
+            The localized or non-localized description.
+        """
+        if not self.description_localizations or not self.description_localizations.data:
+            return self.name
+
+        return self.description_localizations.data.get(str(locale), self.description)
 
 
 @dataclasses.dataclass
@@ -58,16 +101,20 @@ class AppCommand:
     ----------
     id : int
         The command's unique identifier.
-    name : str
-        The name of the command.
+    name: str
+        Command's non-localized name
+    description: str
+        Command's non-localized description
+    name_localizations: disnake.LocalizationValue
+        Contains localizations for the command's name
+    description_localizations: Optional[disnake.LocalizationValue]
+        Contains localizations for the command's description.
     checks : CommandChecks
         The command's permission and role requirements.
     type: AppCommandType
         Type of command
     category: str
         Name of cog or category the command belongs to
-    description : str
-        A brief description of the command.
     dm_permission : bool
         Whether the command is available in DMs or not.
     nsfw : bool
@@ -77,25 +124,76 @@ class AppCommand:
     default_member_permissions : Permissions, optional
         Default member permissions required to use this command.
     mention : str
-        Return the command as a mentionable if slash command, else returns bolded name.
+        Get the command as a mentionable if slash command, else returns bolded name.
+
+    Methods
+    -------
+    get_localized_mention(locale: disnake.Locale)
+    get_localized_name(locale: Optional[Locale])
+        Returns localized or non-localized name.
+    get_localized_description(locale: disnake.Locale)
+        Returns localized or non-localized description.
     """
 
     id: int
     name: str
+    description: str
     checks: CommandChecks
     type: "AppCommandType"
+    name_localizations: LocalizationValue
+    description_localizations: Optional[LocalizationValue] = None
     category: str = "None"
     dm_permission: bool = True
     nsfw: bool = False
-    description: str = "-"
     guild_id: Optional[int] = None
     default_member_permissions: Optional[Permissions] = None
 
     @property
     def mention(self) -> str:
+        """Returns the"""
         if isinstance(self, SlashCommand):
             return f"</{self.name}:{self.id}>"
         return f"**{self.name}**"
+
+    def get_localized_name(self, locale: Locale) -> str:
+        """Returns localized or non-localized name. specified by the provided locale.
+
+        If not available returns the non-localized name instead.
+
+        Parameters
+        ----------
+        locale: disnake.Locale
+            The interaction locale
+
+        Returns
+        -------
+        str
+            The localized or non-localized name.
+        """
+        if not self.name_localizations.data:
+            return self.name
+
+        return self.name_localizations.data.get(str(locale), self.name)
+
+    def get_localized_description(self, locale: Locale) -> str:
+        """Returns localized or non-localized description. specified by the provided locale.
+
+        If not available, returns the non-localized description instead.
+
+        Parameters
+        ----------
+        locale: disnake.Locale
+            The interaction locale
+
+        Returns
+        -------
+        str
+            The localized or non-localized description.
+        """
+        if not self.description_localizations or not self.description_localizations.data:
+            return self.description
+
+        return self.description_localizations.data.get(str(locale), self.description)
 
 
 @dataclasses.dataclass

--- a/src/helply/types/commands.py
+++ b/src/helply/types/commands.py
@@ -47,7 +47,7 @@ class Argument(ArgumentBase):
     get_localized_description(locale: disnake.Locale)
         Returns localized or non-localized description. (*New in version 0.3.0*)
     localize(locale: disnake.Locale)
-        Returns a LocalizedArgument
+        Returns a LocalizedArgument (*New in version 0.3.0*)
     """
 
     def __init__(
@@ -131,6 +131,7 @@ class AppCommand(AppCommandBase):
     AppCommands are classes that include various attributes from both
     `.ApplicationCommand` and `.InvokableApplicationCommand`
 
+
     Attributes
     ----------
     id : int
@@ -151,9 +152,12 @@ class AppCommand(AppCommandBase):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    description_localizations: Optional[LocalizationValue]
+        Contains localization information for the command's description. (*SlashCommand only*)
+        (*New in version 0.3.0*)
     guild_id : Optional[int]
         The ID of the guild where the command is available.
-    default_member_permissions : Permissions, optional
+    default_member_permissions : Optional[Permissions]
         Default member permissions required to use this command.
     mention : str
         Get the command as a mentionable if slash command, else returns bolded name.
@@ -165,7 +169,7 @@ class AppCommand(AppCommandBase):
     get_localized_description(locale: disnake.Locale)
         Returns localized or non-localized description. (*New in version 0.3.0*)
     localize(locale: disnake.Locale)
-        Returns a LocalizedAppcommand, or sub-variant
+        Returns a LocalizedAppcommand, or sub-variant (*New in version 0.3.0*)
     """
 
     def __init__(
@@ -179,9 +183,9 @@ class AppCommand(AppCommandBase):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        description_localizations: Optional[LocalizationValue] = None,
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
-        description_localizations: Optional[LocalizationValue] = None,
     ) -> None:
         super().__init__(
             id=id,
@@ -247,6 +251,7 @@ class AppCommand(AppCommandBase):
             args = [a.localize(locale) for a in self.args]
             return LocalizedSlashCommand(
                 id=self.id,
+                _name=self.name,
                 name=name,
                 description=description,
                 args=args,
@@ -262,6 +267,7 @@ class AppCommand(AppCommandBase):
         if isinstance(self, UserCommand):
             return LocalizedUserCommand(
                 id=self.id,
+                _name=self.name,
                 name=name,
                 description=description,
                 checks=self.checks,
@@ -275,6 +281,7 @@ class AppCommand(AppCommandBase):
 
         return LocalizedMessageCommand(
             id=self.id,
+            _name=self.name,
             name=name,
             description=description,
             checks=self.checks,
@@ -316,7 +323,7 @@ class SlashCommand(AppCommand):
         Whether the command is NSFW (Not Safe For Work).
     guild_id : Optional[int]
         The ID of the guild where the command is available.
-    default_member_permissions : Permissions, optional
+    default_member_permissions : Optional[Permissions]
         Default member permissions required to use this command.
     mention : str
         Get the command as a mentionable if slash command, else returns bolded name.
@@ -391,7 +398,7 @@ class UserCommand(AppCommand):
         Whether the command is NSFW (Not Safe For Work).
     guild_id : Optional[int]
         The ID of the guild where the command is available.
-    default_member_permissions : Permissions, optional
+    default_member_permissions : Optional[Permissions]
         Default member permissions required to use this command.
     mention : str
         Get the command as a mentionable if slash command, else returns bolded name.
@@ -403,7 +410,7 @@ class UserCommand(AppCommand):
     get_localized_description(locale: disnake.Locale)
         Returns localized or non-localized description. (*New in version 0.3.0*)
     localize(locale: disnake.Locale)
-        Returns a LocalizedAppcommand, or sub-variant
+        Returns a LocalizedAppcommand, or sub-variant. (*New in version 0.3.0*)
     """
 
     def __init__(
@@ -460,7 +467,7 @@ class MessageCommand(AppCommand):
         Whether the command is NSFW (Not Safe For Work).
     guild_id : Optional[int]
         The ID of the guild where the command is available.
-    default_member_permissions : Permissions, optional
+    default_member_permissions : Optional[Permissions]
         Default member permissions required to use this command.
     mention : str
         Get the command as a mentionable if slash command, else returns bolded name.

--- a/src/helply/types/commands.py
+++ b/src/helply/types/commands.py
@@ -1,10 +1,9 @@
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from disnake import Locale, LocalizationValue, Permissions
 
 from .abc_ import AppCommandBase, ArgumentBase
 from .checks import CommandChecks
-from .enums import AppCommandType
 from .localized import (
     LocalizedAppCommand,
     LocalizedArgument,
@@ -12,6 +11,9 @@ from .localized import (
     LocalizedSlashCommand,
     LocalizedUserCommand,
 )
+
+if TYPE_CHECKING:
+    from .enums import AppCommandType
 
 __all__ = (
     "Argument",
@@ -134,9 +136,9 @@ class AppCommand(AppCommandBase):
     id : int
         The command's unique identifier.
     name: str
-        Command's non-localized name
+        Command's  name
     description: str
-        Command's non-localized description
+        Command's description
     name_localizations: disnake.LocalizationValue
         Contains localizations for the command's name. (*New in version 0.3.0*)
     checks : CommandChecks
@@ -172,7 +174,7 @@ class AppCommand(AppCommandBase):
         name: str,
         description: str,
         checks: CommandChecks,
-        type: AppCommandType,
+        type: "AppCommandType",
         name_localizations: LocalizationValue,
         category: str,
         dm_permission: bool,
@@ -335,7 +337,7 @@ class SlashCommand(AppCommand):
         name: str,
         description: str,
         checks: CommandChecks,
-        type: AppCommandType,
+        type: "AppCommandType",
         args: List[Argument],
         name_localizations: LocalizationValue,
         description_localizations: LocalizationValue,
@@ -410,7 +412,7 @@ class UserCommand(AppCommand):
         name: str,
         description: str,
         checks: CommandChecks,
-        type: AppCommandType,
+        type: "AppCommandType",
         name_localizations: LocalizationValue,
         category: str,
         dm_permission: bool,
@@ -479,7 +481,7 @@ class MessageCommand(AppCommand):
         name: str,
         description: str,
         checks: CommandChecks,
-        type: AppCommandType,
+        type: "AppCommandType",
         name_localizations: LocalizationValue,
         category: str,
         dm_permission: bool,

--- a/src/helply/types/commands.py
+++ b/src/helply/types/commands.py
@@ -31,16 +31,16 @@ class Argument:
     required: bool
         Whether or not the argument is required.
     name_localizations: disnake.LocalizationValue
-        Contains localizations for the argument's name
+        Contains localizations for the argument's name. (*New in version 0.3.0*)
     description_localizations: disnake.LocalizationValue
-        Contains localizations for the argument's description.
+        Contains localizations for the argument's description. (*New in version 0.3.0*)
 
     Methods
     -------
     get_localized_name(locale: disnake.Locale)
-        Returns localized or non-localized name.
+        Returns localized or non-localized name. (*New in version 0.3.0*)
     get_localized_description(locale: disnake.Locale)
-        Returns localized or non-localized description.
+        Returns localized or non-localized description. (*New in version 0.3.0*)
     """
 
     name: str
@@ -106,9 +106,9 @@ class AppCommand:
     description: str
         Command's non-localized description
     name_localizations: disnake.LocalizationValue
-        Contains localizations for the command's name
+        Contains localizations for the command's name. (*New in version 0.3.0*)
     description_localizations: Optional[disnake.LocalizationValue]
-        Contains localizations for the command's description.
+        Contains localizations for the command's description. (*New in version 0.3.0*)
     checks : CommandChecks
         The command's permission and role requirements.
     type: AppCommandType
@@ -128,11 +128,10 @@ class AppCommand:
 
     Methods
     -------
-    get_localized_mention(locale: disnake.Locale)
     get_localized_name(locale: Optional[Locale])
-        Returns localized or non-localized name.
+        Returns localized or non-localized name. (*New in version 0.3.0*)
     get_localized_description(locale: disnake.Locale)
-        Returns localized or non-localized description.
+        Returns localized or non-localized description. (*New in version 0.3.0*)
     """
 
     id: int
@@ -150,10 +149,10 @@ class AppCommand:
 
     @property
     def mention(self) -> str:
-        """Returns the"""
+        """Returns the a clickable tagged command or bolded command name if not SlashCommand"""
         if isinstance(self, SlashCommand):
             return f"</{self.name}:{self.id}>"
-        return f"**{self.name}**"
+        return f"*{self.name}*"
 
     def get_localized_name(self, locale: Locale) -> str:
         """Returns localized or non-localized name. specified by the provided locale.

--- a/src/helply/types/enums.py
+++ b/src/helply/types/enums.py
@@ -1,20 +1,22 @@
 import enum
 
-from .commands import MessageCommand, SlashCommand, UserCommand
-
 __all__ = ("AppCommandType",)
 
 
-class AppCommandType(enum.Enum):
-    """Enum for AppCommandType
+class AppCommandType(str, enum.Enum):
+    """Represents a command type.
 
     Attributes
     ----------
-    slash: SlashCommand
-    message: MessageCommand
-    user UserCommand
+    SLASH
+        "slash"
+    MESSAGE
+        "message"
+    USER
+        "user"
+
     """
 
-    slash = SlashCommand
-    message = MessageCommand
-    user = UserCommand
+    SLASH = "slash"
+    MESSAGE = "message"
+    USER = "user"

--- a/src/helply/types/localized.py
+++ b/src/helply/types/localized.py
@@ -16,14 +16,52 @@ __all__ = (
 
 
 class LocalizedArgument(ArgumentBase):
-    """Represents a slash command argument with localized attributes"""
+    """Represents a slash command argument with localized attributes
+
+    Attributes
+    ----------
+    name: str
+        Argument's non-localized name
+    description: str
+        Argument's non-localized description
+    required: bool
+        Whether or not the argument is required
+    """
 
     def __init__(self, name: str, description: str, required: bool) -> None:
         super().__init__(name=name, description=description, required=required)
 
 
 class LocalizedAppCommand(AppCommandBase):
-    """Represents an AppCommand with localized attributes"""
+    """Represents an AppCommand with localized attributes
+
+    Attributes
+    ----------
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's name
+    description: str
+        Command's description
+    name_localizations: disnake.LocalizationValue
+        Contains localizations for the command's name. (*New in version 0.3.0*)
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : Optional[int]
+        The ID of the guild where the command is available.
+    default_member_permissions : Permissions, optional
+        Default member permissions required to use this command.
+    mention : str
+        Get the command as a mentionable if slash command, else returns bolded name.
+    """
 
     def __init__(
         self,

--- a/src/helply/types/localized.py
+++ b/src/helply/types/localized.py
@@ -1,0 +1,150 @@
+from typing import List, Optional
+
+from disnake import Permissions
+
+from .abc_ import AppCommandBase, ArgumentBase
+from .checks import CommandChecks
+from .enums import AppCommandType
+
+__all__ = (
+    "LocalizedArgument",
+    "LocalizedAppCommand",
+    "LocalizedSlashCommand",
+    "LocalizedUserCommand",
+    "LocalizedMessageCommand",
+)
+
+
+class LocalizedArgument(ArgumentBase):
+    """Represents a slash command argument with localized attributes"""
+
+    def __init__(self, name: str, description: str, required: bool) -> None:
+        super().__init__(name=name, description=description, required=required)
+
+
+class LocalizedAppCommand(AppCommandBase):
+    """Represents an AppCommand with localized attributes"""
+
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        description: str,
+        checks: CommandChecks,
+        type: AppCommandType,
+        category: str,
+        dm_permission: bool,
+        nsfw: bool,
+        guild_id: Optional[int] = None,
+        default_member_permissions: Optional[Permissions] = None,
+    ) -> None:
+        super().__init__(
+            id=id,
+            name=name,
+            description=description,
+            checks=checks,
+            type=type,
+            category=category,
+            dm_permission=dm_permission,
+            nsfw=nsfw,
+            guild_id=guild_id,
+            default_member_permissions=default_member_permissions,
+        )
+
+
+class LocalizedSlashCommand(LocalizedAppCommand):
+    """Represents a slash command type AppCommand
+
+    Attributes
+    ----------
+    args: List[Argument]
+    """
+
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        description: str,
+        checks: CommandChecks,
+        type: AppCommandType,
+        args: List[LocalizedArgument],
+        category: str,
+        dm_permission: bool,
+        nsfw: bool,
+        guild_id: Optional[int] = None,
+        default_member_permissions: Optional[Permissions] = None,
+    ) -> None:
+        super().__init__(
+            id=id,
+            name=name,
+            description=description,
+            checks=checks,
+            type=type,
+            category=category,
+            dm_permission=dm_permission,
+            nsfw=nsfw,
+            guild_id=guild_id,
+            default_member_permissions=default_member_permissions,
+        )
+
+        self.args: List[LocalizedArgument] = args
+
+
+class LocalizedUserCommand(LocalizedAppCommand):
+    """Represents a user command type AppCommand"""
+
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        description: str,
+        checks: CommandChecks,
+        type: AppCommandType,
+        category: str,
+        dm_permission: bool,
+        nsfw: bool,
+        guild_id: Optional[int] = None,
+        default_member_permissions: Optional[Permissions] = None,
+    ) -> None:
+        super().__init__(
+            id=id,
+            name=name,
+            description=description,
+            checks=checks,
+            type=type,
+            category=category,
+            dm_permission=dm_permission,
+            nsfw=nsfw,
+            guild_id=guild_id,
+            default_member_permissions=default_member_permissions,
+        )
+
+
+class LocalizedMessageCommand(LocalizedAppCommand):
+    """Represents a message command type AppCommand"""
+
+    def __init__(
+        self,
+        id: int,
+        name: str,
+        description: str,
+        checks: CommandChecks,
+        type: AppCommandType,
+        category: str,
+        dm_permission: bool,
+        nsfw: bool,
+        guild_id: Optional[int] = None,
+        default_member_permissions: Optional[Permissions] = None,
+    ) -> None:
+        super().__init__(
+            id=id,
+            name=name,
+            description=description,
+            checks=checks,
+            type=type,
+            category=category,
+            dm_permission=dm_permission,
+            nsfw=nsfw,
+            guild_id=guild_id,
+            default_member_permissions=default_member_permissions,
+        )

--- a/src/helply/types/localized.py
+++ b/src/helply/types/localized.py
@@ -40,11 +40,9 @@ class LocalizedAppCommand(AppCommandBase):
     id : int
         The command's unique identifier.
     name: str
-        Command's name
+        Command's localized name
     description: str
-        Command's description
-    name_localizations: disnake.LocalizationValue
-        Contains localizations for the command's name. (*New in version 0.3.0*)
+        Command's localized description
     checks : CommandChecks
         The command's permission and role requirements.
     type: AppCommandType
@@ -57,7 +55,7 @@ class LocalizedAppCommand(AppCommandBase):
         Whether the command is NSFW (Not Safe For Work).
     guild_id : Optional[int]
         The ID of the guild where the command is available.
-    default_member_permissions : Permissions, optional
+    default_member_permissions : Optional[Permissions]
         Default member permissions required to use this command.
     mention : str
         Get the command as a mentionable if slash command, else returns bolded name.
@@ -66,6 +64,7 @@ class LocalizedAppCommand(AppCommandBase):
     def __init__(
         self,
         id: int,
+        _name: str,
         name: str,
         description: str,
         checks: CommandChecks,
@@ -89,18 +88,52 @@ class LocalizedAppCommand(AppCommandBase):
             default_member_permissions=default_member_permissions,
         )
 
+        self._name: str = _name
+
+    @property
+    def mention(self) -> str:
+        """Returns the mentionable command if slash type, else bolded name"""
+        if self.type is AppCommandType.SLASH:
+            return f"</{self._name}:{self.id}>"
+
+        return f"**{self._name}**"
+
 
 class LocalizedSlashCommand(LocalizedAppCommand):
     """Represents a slash command type AppCommand
 
     Attributes
     ----------
-    args: List[Argument]
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's localized name
+    description: str
+        Command's localized description
+    args: List[LocalizedArgument]
+        Command's localized arguments.
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : Optional[int]
+        The ID of the guild where the command is available.
+    default_member_permissions : Optional[Permissions]
+        Default member permissions required to use this command.
+    mention : str
+        Get the command as selectable tag.
     """
 
     def __init__(
         self,
         id: int,
+        _name: str,
         name: str,
         description: str,
         checks: CommandChecks,
@@ -114,6 +147,7 @@ class LocalizedSlashCommand(LocalizedAppCommand):
     ) -> None:
         super().__init__(
             id=id,
+            _name=_name,
             name=name,
             description=description,
             checks=checks,
@@ -129,11 +163,39 @@ class LocalizedSlashCommand(LocalizedAppCommand):
 
 
 class LocalizedUserCommand(LocalizedAppCommand):
-    """Represents a user command type AppCommand"""
+    """Represents a UserCommand with localized attributes.
+
+        Attributes
+    ----------
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's localized name
+    description: str
+        Command's localized description
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : Optional[int]
+        The ID of the guild where the command is available.
+    default_member_permissions : Optional[Permissions]
+        Default member permissions required to use this command.
+    mention : str
+        Get the command name, bolded.
+
+    """
 
     def __init__(
         self,
         id: int,
+        _name: str,
         name: str,
         description: str,
         checks: CommandChecks,
@@ -146,6 +208,7 @@ class LocalizedUserCommand(LocalizedAppCommand):
     ) -> None:
         super().__init__(
             id=id,
+            _name=_name,
             name=name,
             description=description,
             checks=checks,
@@ -159,11 +222,38 @@ class LocalizedUserCommand(LocalizedAppCommand):
 
 
 class LocalizedMessageCommand(LocalizedAppCommand):
-    """Represents a message command type AppCommand"""
+    """Represents a MessageCommand with localized attributes
+
+        Attributes
+    ----------
+    id : int
+        The command's unique identifier.
+    name: str
+        Command's localized name
+    description: str
+        Command's localized description
+    checks : CommandChecks
+        The command's permission and role requirements.
+    type: AppCommandType
+        Type of command
+    category: str
+        Name of cog or category the command belongs to
+    dm_permission : bool
+        Whether the command is available in DMs or not.
+    nsfw : bool
+        Whether the command is NSFW (Not Safe For Work).
+    guild_id : Optional[int]
+        The ID of the guild where the command is available.
+    default_member_permissions : Optional[Permissions]
+        Default member permissions required to use this command.
+    mention : str
+        Get the command name, bolded.
+    """
 
     def __init__(
         self,
         id: int,
+        _name: str,
         name: str,
         description: str,
         checks: CommandChecks,
@@ -176,6 +266,7 @@ class LocalizedMessageCommand(LocalizedAppCommand):
     ) -> None:
         super().__init__(
             id=id,
+            _name=_name,
             name=name,
             description=description,
             checks=checks,

--- a/tests/locale/de.json
+++ b/tests/locale/de.json
@@ -1,0 +1,16 @@
+{
+    "HIGHSCORE_COMMAND_NAME": "rekord",
+    "HIGHSCORE_COMMAND_DESCRIPTION": "Zeigt die Rekordpunktzahl des Users innerhalb des gewählten Zeitraums.",
+    "HIGHSCORE_USER_NAME": "user",
+    "HIGHSCORE_USER_DESCRIPTION": "Der User, dessen Punktzahl gezeigt werden soll.",
+    "HIGHSCORE_GAME_NAME": "spiel",
+    "HIGHSCORE_GAME_DESCRIPTION": "Spiel, für das Punktzahlen gefiltert werden.",
+    "HIGHSCORE_RANGE_NAME": "zeitraum",
+    "HIGHSCORE_RANGE_DESCRIPTION": "Der Zeitraum zur Berechnung der Rekordpunktzahl.",
+    "CHOICE_DAY": "Letzter Tag",
+    "CHOICE_WEEK": "Letzte Woche",
+    "CHOICE_MONTH": "Letzter Monat",
+    "GAME_TIC-TAC-TOE": "Tic-Tac-Toe",
+    "GAME_CHESS": "Schach",
+    "GAME_RISK": "Risiko"
+}

--- a/tests/locale/es_ES.json
+++ b/tests/locale/es_ES.json
@@ -1,0 +1,16 @@
+{
+    "HIGHSCORE_COMMAND_NAME": "puntuación",
+    "HIGHSCORE_COMMAND_DESCRIPTION": "Muestra la puntuación récord del usuario en el período elegido.",
+    "HIGHSCORE_USER_NAME": "usuario",
+    "HIGHSCORE_USER_DESCRIPTION": "Usuario cuya puntuación se mostrará.",
+    "HIGHSCORE_GAME_NAME": "juego",
+    "HIGHSCORE_GAME_DESCRIPTION": "Juego para filtrar las puntuaciones.",
+    "HIGHSCORE_RANGE_NAME": "período",
+    "HIGHSCORE_RANGE_DESCRIPTION": "Período para calcular la puntuación récord.",
+    "CHOICE_DAY": "Último día",
+    "CHOICE_WEEK": "Última semana",
+    "CHOICE_MONTH": "Último mes",
+    "GAME_TIC-TAC-TOE": "Tres en raya",
+    "GAME_CHESS": "Ajedrez",
+    "GAME_RISK": "Riesgo"
+}

--- a/tests/localization.py
+++ b/tests/localization.py
@@ -1,0 +1,93 @@
+import os
+from typing import Any
+
+import disnake
+from disnake import Localized, OptionChoice
+from disnake.ext import commands
+
+from helply import Helply, utils
+
+intents = disnake.Intents.default()
+bot = commands.InteractionBot()
+helply = Helply(bot)
+
+
+bot.i18n.load(f"{os.path.dirname(__file__)}/locale/")
+
+
+@bot.slash_command()
+async def highscore(
+    inter: disnake.CommandInteraction,
+    user: disnake.User,
+    game: str,
+    interval: str = commands.Param(
+        choices=[
+            OptionChoice(Localized("Last Day", key="CHOICE_DAY"), "day"),
+            OptionChoice(Localized("Last Week", key="CHOICE_WEEK"), "week"),
+            OptionChoice(Localized("Last Month", key="CHOICE_MONTH"), "month"),
+        ]
+    ),
+):
+    """Shows the highscore of the selected user within the specified interval.
+    {{ HIGHSCORE_COMMAND }}
+
+    Parameters
+    ----------
+    user: The user to show data for. {{ HIGHSCORE_USER }}
+    game: Which game to check scores in. {{ HIGHSCORE_GAME }}
+    interval: The time interval to use. {{ HIGHSCORE_RANGE }}
+    """
+    db: Any = ...  # a placeholder for an actual database connection
+    data = await db.highscores.find(user=user.id, game=game).filter(interval).max()
+    await inter.send(f"max: {data}")
+
+
+@highscore.autocomplete("game")
+async def game_autocomp(inter: disnake.CommandInteraction, string: str):
+    # this clearly isn't great autocompletion as it autocompletes based on the English name,
+    # but for the purposes of this example it'll do
+    games = ("Tic-tac-toe", "Chess", "Risk")
+    return [
+        Localized(game, key=f"GAME_{game.upper()}")
+        for game in games
+        if string.lower() in game.lower()
+    ]
+
+
+@bot.slash_command(name="help")
+async def help_command(
+    inter: disnake.ApplicationCommandInteraction,
+    _command: str = commands.Param(None, name="command"),
+):
+    if _command:
+        command = helply.get_command(int(_command))
+
+        embed = utils.command_detail_embed(command, locale=disnake.Locale.de)
+        await inter.send(embed=embed)
+        return
+
+    commands = helply.get_all_commands()
+    embeds = utils.commands_overview_embeds(commands, locale=disnake.Locale.de)
+    embed = embeds[0]
+
+    await inter.send(embed=embed)
+
+
+@help_command.autocomplete("command")
+async def help_command_autocomplete(inter: disnake.AppCommandInter, command: str) -> dict[str, str]:
+    commands = helply.get_all_commands()
+
+    locale = disnake.Locale.de  # inter.locale
+
+    return {
+        c.get_localized_name(locale): str(c.id)
+        for c in commands
+        if command.casefold() in c.get_localized_name(locale).casefold()
+    }
+
+
+if __name__ == "__main__":
+    import dotenv
+
+    dotenv.load_dotenv()
+    bot.run(os.getenv("TOKEN"))

--- a/tests/localization.py
+++ b/tests/localization.py
@@ -60,14 +60,14 @@ async def help_command(
     _command: str = commands.Param(None, name="command"),
 ):
     if _command:
-        command = helply.get_command(int(_command))
+        command = helply.get_command(int(_command), locale=inter.locale)
+        embed = utils.command_detail_embed(command)
 
-        embed = utils.command_detail_embed(command, locale=disnake.Locale.de)
         await inter.send(embed=embed)
         return
 
-    commands = helply.get_all_commands()
-    embeds = utils.commands_overview_embeds(commands, locale=disnake.Locale.de)
+    commands = helply.get_all_commands(locale=inter.locale)
+    embeds = utils.commands_overview_embeds(commands)
     embed = embeds[0]
 
     await inter.send(embed=embed)


### PR DESCRIPTION
This PR adds the following new features:

- application name and description localization
- slash command argument localization

You will now be able to pass a `locale` argument to most all of the `get_` methods and receive a localized instance of the requested AppCommand.

This new object includes the localized name, description, and arguments (if slash).
If the locale is not mapped in the command's localization data, non-localized values are used instead.

SlashCommand -> LocalizedSlashCommand
MessageCommand -> LocalizedMessageCommand
UserCommand -> LocalizedUserCommand

This PR also restructures the internal classing system, which should not impact end-users and does not break existing methods.

However, there is one breaking change:
- `get_all_commands` is being renamed to `get_commands` simply because I just didn't like the way it looked.  There remains an alias, so it's still usable for now.  Deprecation has been documented