### PR TITLE
feat: add cooldown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ and provide details for each command, such as name, description, role and permis
 ## Key Features
 - Consolidating various attributes from `InvokableApplicationCommand` and `APIApplicationCommand` into a single cached object.
 - Parsing role and permission checks.
-- Support localizing commands and arguments (*New in version 0.3.0*)
 - Utility functions that provide ready-to-go embeds and pagination.
-
+- Support localizing commands and arguments (*New in version 0.3.0*)
+- Parsing command cooldowns (*New in version 0.4.0*)
 
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,10 @@ and provide details for each command, such as name, description, role and permis
 ## Key Features
 - Consolidating various attributes from `InvokableApplicationCommand` and `APIApplicationCommand` into a single cached object.
 - Parsing role and permission checks.
+- Parsing command cooldowns (*New in version 0.4.0*)
 - Support localizing commands and arguments (*New in version 0.3.0*)
 - Utility functions that provide ready-to-go embeds and pagination.
+
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "helply"
-version = "0.3.3"
+version = "0.4.0"
 description = "A library that simplifies 'help' command creation for application commands in your discord bot."
 authors = ["DLCHAMP <contact@dlchamp.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "helply"
-version = "0.4.0"
+version = "0.4.1"
 description = "A library that simplifies 'help' command creation for application commands in your discord bot."
 authors = ["DLCHAMP <contact@dlchamp.com>"]
 license = "MIT"

--- a/src/helply/__init__.py
+++ b/src/helply/__init__.py
@@ -9,7 +9,7 @@ in your disnake bot.
 """
 
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"
 
 
 from .helply import Helply

--- a/src/helply/__init__.py
+++ b/src/helply/__init__.py
@@ -9,7 +9,7 @@ in your disnake bot.
 """
 
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 from .helply import Helply

--- a/src/helply/helply.py
+++ b/src/helply/helply.py
@@ -545,7 +545,8 @@ class Helply:
             if locale:
                 command = command.localize(locale)
 
-            commands.append(command)
+            if command not in commands:
+                commands.append(command)
 
         return commands  # type: ignore - I don't know how to fix this yet ;)
 

--- a/src/helply/helply.py
+++ b/src/helply/helply.py
@@ -441,7 +441,7 @@ class Helply:
                     self._app_commands[user_command.id] = user_command
 
     @overload
-    def get_commands(
+    def get_all_commands(
         self,
         guild_id: Optional[int] = None,
         *,
@@ -454,7 +454,7 @@ class Helply:
         ...
 
     @overload
-    def get_commands(
+    def get_all_commands(
         self,
         guild_id: Optional[int] = None,
         *,
@@ -466,7 +466,7 @@ class Helply:
     ) -> List[AppCommand]:
         ...
 
-    def get_commands(
+    def get_all_commands(
         self,
         guild_id: Optional[int] = None,
         *,
@@ -480,6 +480,10 @@ class Helply:
 
         By default, this method should return all registered commands. Specify filters
         to narrow down the output results.
+
+        !!! Warning
+            This method is deprecated as of *version 0.4.0* and will be replaced by it's current
+            alias `get_commands`.
 
         Parameters
         ----------
@@ -545,8 +549,8 @@ class Helply:
 
         return commands  # type: ignore - I don't know how to fix this yet ;)
 
-    # temporary alias - will be deprecated
-    get_all_commands = get_commands
+    # temporary alias - get_all_commands will be removed, eventually
+    get_commands = get_all_commands
 
     @overload
     def get_command(self, id: int, locale: None = None) -> Optional[AppCommand]:

--- a/src/helply/types/abc_.py
+++ b/src/helply/types/abc_.py
@@ -56,7 +56,7 @@ class AppCommandBase(ABC):
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
     cooldown: Optional[Cooldown]
-        The configured cooldown, if available
+        The configured cooldown, if available (*New in 0.4.0*)
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Permissions, optional

--- a/src/helply/types/abc_.py
+++ b/src/helply/types/abc_.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from disnake import Permissions
 
-from .checks import CommandChecks
+from .checks import CommandChecks, Cooldown
 from .enums import AppCommandType
 
 __all__ = (
@@ -55,6 +55,8 @@ class AppCommandBase(ABC):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Permissions, optional
@@ -73,6 +75,7 @@ class AppCommandBase(ABC):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -84,6 +87,7 @@ class AppCommandBase(ABC):
         self.category = category
         self.dm_permission = dm_permission
         self.nsfw = nsfw
+        self.cooldown = cooldown
         self.guild_id = guild_id
         self.default_member_permissions = default_member_permissions
 

--- a/src/helply/types/abc_.py
+++ b/src/helply/types/abc_.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Optional
+from typing import Any, Optional
 
 from disnake import Permissions
 
@@ -79,20 +79,32 @@ class AppCommandBase(ABC):
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
-        self.id = id
-        self.name = name
-        self.description = description
-        self.checks = checks
-        self.type = type
-        self.category = category
-        self.dm_permission = dm_permission
-        self.nsfw = nsfw
-        self.cooldown = cooldown
-        self.guild_id = guild_id
-        self.default_member_permissions = default_member_permissions
+        self.id: int = id
+        self.name: str = name
+        self.description: str = description
+        self.checks: CommandChecks = checks
+        self.type: AppCommandType = type
+        self.category: str = category
+        self.dm_permission: bool = dm_permission
+        self.nsfw: bool = nsfw
+        self.cooldown: Optional[Cooldown] = cooldown
+        self.guild_id: Optional[int] = guild_id
+        self.default_member_permissions: Optional[Permissions] = default_member_permissions
 
     @property
     def mention(self) -> str:
         if self.type is AppCommandType.SLASH:
             return f"</{self.name}:{self.id}>"
         return f"**{self.name}**"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+
+        return (
+            self.name == other.name
+            and self.type == other.type
+            and self.category == other.category
+            and self.nsfw == other.nsfw
+            and self.default_member_permissions == other.default_member_permissions
+        )

--- a/src/helply/types/checks.py
+++ b/src/helply/types/checks.py
@@ -1,9 +1,12 @@
-import typing
+from typing import List, NamedTuple, Union
 
-__all__ = ("CommandChecks",)
+__all__ = (
+    "CommandChecks",
+    "Cooldown",
+)
 
 
-class CommandChecks(typing.NamedTuple):
+class CommandChecks(NamedTuple):
     """Wrap the command's permission or role requirements.
 
     Attributes
@@ -14,5 +17,41 @@ class CommandChecks(typing.NamedTuple):
         A list of role names or role IDs required to use this command.
     """
 
-    permissions: typing.List[str]
-    roles: typing.List[typing.Union[str, int]]
+    permissions: List[str]
+    roles: List[Union[str, int]]
+
+
+class Cooldown(NamedTuple):
+    """Represents a commands.Cooldown
+
+    (*New in version: 0.4.0*)
+
+    Attributes
+    ----------
+    rate: int
+        Number of times the command can be used before triggering a cooldown
+    per: float
+        Amount of seconds to wait for a cooldown when it's been triggered
+    type: str
+        Type of cooldown
+
+
+
+    ```
+    |--------------------------------------------------------------------|
+    |   Types    |                   Description                         |
+    |------------|-------------------------------------------------------|
+    | `default`  | The default bucket operates on a global basis.        |
+    | `user`     | The user bucket operates on a per-user basis.         |
+    | `guild`    | The guild bucket operates on a per-guild basis.       |
+    | `channel`  | The channel bucket operates on a per-channel basis.   |
+    | `member`   | The member bucket operates on a per-member basis.     |
+    | `category` | The category bucket operates on a per-category basis. |
+    | `role`     | The role bucket operates on a per-role basis.         |
+    |--------------------------------------------------------------------|
+    ```
+    """
+
+    rate: int
+    per: float
+    type: str

--- a/src/helply/types/commands.py
+++ b/src/helply/types/commands.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, List, Optional
 from disnake import Locale, LocalizationValue, Permissions
 
 from .abc_ import AppCommandBase, ArgumentBase
-from .checks import CommandChecks
+from .checks import CommandChecks, Cooldown
 from .localized import (
     LocalizedAppCommand,
     LocalizedArgument,
@@ -155,6 +155,8 @@ class AppCommand(AppCommandBase):
     description_localizations: Optional[LocalizationValue]
         Contains localization information for the command's description. (*SlashCommand only*)
         (*New in version 0.3.0*)
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -183,6 +185,7 @@ class AppCommand(AppCommandBase):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         description_localizations: Optional[LocalizationValue] = None,
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
@@ -196,6 +199,7 @@ class AppCommand(AppCommandBase):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )
@@ -259,6 +263,7 @@ class AppCommand(AppCommandBase):
                 type=self.type,
                 category=self.category,
                 nsfw=self.nsfw,
+                cooldown=self.cooldown,
                 dm_permission=self.dm_permission,
                 guild_id=self.guild_id,
                 default_member_permissions=self.default_member_permissions,
@@ -275,6 +280,7 @@ class AppCommand(AppCommandBase):
                 dm_permission=self.dm_permission,
                 category=self.category,
                 nsfw=self.nsfw,
+                cooldown=self.cooldown,
                 guild_id=self.guild_id,
                 default_member_permissions=self.default_member_permissions,
             )
@@ -289,6 +295,7 @@ class AppCommand(AppCommandBase):
             dm_permission=self.dm_permission,
             category=self.category,
             nsfw=self.nsfw,
+            cooldown=self.cooldown,
             guild_id=self.guild_id,
             default_member_permissions=self.default_member_permissions,
         )
@@ -321,6 +328,8 @@ class SlashCommand(AppCommand):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -351,6 +360,7 @@ class SlashCommand(AppCommand):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -365,6 +375,7 @@ class SlashCommand(AppCommand):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )
@@ -396,6 +407,8 @@ class UserCommand(AppCommand):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -424,6 +437,7 @@ class UserCommand(AppCommand):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -437,6 +451,7 @@ class UserCommand(AppCommand):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )
@@ -465,6 +480,8 @@ class MessageCommand(AppCommand):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -493,6 +510,7 @@ class MessageCommand(AppCommand):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -506,6 +524,7 @@ class MessageCommand(AppCommand):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )

--- a/src/helply/types/commands.py
+++ b/src/helply/types/commands.py
@@ -156,7 +156,7 @@ class AppCommand(AppCommandBase):
         Contains localization information for the command's description. (*SlashCommand only*)
         (*New in version 0.3.0*)
     cooldown: Optional[Cooldown]
-        The configured cooldown, if available
+        The configured cooldown, if available. (*New in 0.4.0*)
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -329,7 +329,7 @@ class SlashCommand(AppCommand):
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
     cooldown: Optional[Cooldown]
-        The configured cooldown, if available
+        The configured cooldown, if available. (*New in 0.4.0*)
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -408,7 +408,7 @@ class UserCommand(AppCommand):
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
     cooldown: Optional[Cooldown]
-        The configured cooldown, if available
+        The configured cooldown, if available. (*New in 0.4.0*)
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -481,7 +481,7 @@ class MessageCommand(AppCommand):
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
     cooldown: Optional[Cooldown]
-        The configured cooldown, if available
+        The configured cooldown, if available. (*New in 0.4.0*)
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]

--- a/src/helply/types/localized.py
+++ b/src/helply/types/localized.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from disnake import Permissions
 
 from .abc_ import AppCommandBase, ArgumentBase
-from .checks import CommandChecks
+from .checks import CommandChecks, Cooldown
 from .enums import AppCommandType
 
 __all__ = (
@@ -53,6 +53,8 @@ class LocalizedAppCommand(AppCommandBase):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -72,6 +74,7 @@ class LocalizedAppCommand(AppCommandBase):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -84,6 +87,7 @@ class LocalizedAppCommand(AppCommandBase):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )
@@ -122,6 +126,8 @@ class LocalizedSlashCommand(LocalizedAppCommand):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -142,6 +148,7 @@ class LocalizedSlashCommand(LocalizedAppCommand):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -155,6 +162,7 @@ class LocalizedSlashCommand(LocalizedAppCommand):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )
@@ -183,6 +191,8 @@ class LocalizedUserCommand(LocalizedAppCommand):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -203,6 +213,7 @@ class LocalizedUserCommand(LocalizedAppCommand):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -216,6 +227,7 @@ class LocalizedUserCommand(LocalizedAppCommand):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )
@@ -242,6 +254,8 @@ class LocalizedMessageCommand(LocalizedAppCommand):
         Whether the command is available in DMs or not.
     nsfw : bool
         Whether the command is NSFW (Not Safe For Work).
+    cooldown: Optional[Cooldown]
+        The configured cooldown, if available
     guild_id : Optional[int]
         The ID of the guild where the command is available.
     default_member_permissions : Optional[Permissions]
@@ -261,6 +275,7 @@ class LocalizedMessageCommand(LocalizedAppCommand):
         category: str,
         dm_permission: bool,
         nsfw: bool,
+        cooldown: Optional[Cooldown],
         guild_id: Optional[int] = None,
         default_member_permissions: Optional[Permissions] = None,
     ) -> None:
@@ -274,6 +289,7 @@ class LocalizedMessageCommand(LocalizedAppCommand):
             category=category,
             dm_permission=dm_permission,
             nsfw=nsfw,
+            cooldown=cooldown,
             guild_id=guild_id,
             default_member_permissions=default_member_permissions,
         )

--- a/src/helply/utils/embeds.py
+++ b/src/helply/utils/embeds.py
@@ -82,6 +82,11 @@ def command_detail_embed(
     if thumbnail:
         embed.set_thumbnail(file=thumbnail)
 
+    if command.cooldown:
+        cooldown = command.cooldown
+        text = f"{cooldown.rate} / {cooldown.per}s / {cooldown.type}"
+        embed.add_field(name="Cooldown", value=text, inline=False)
+
     if command.checks.permissions:
         permissions = ", ".join(command.checks.permissions)
         embed.add_field(name="Required Permissions", value=permissions, inline=True)
@@ -147,7 +152,7 @@ def commands_overview_embeds(
 
     ...
     commands = app_command_help.get_all_commands(inter.guild)
-    embeds = utils.commands_overview_embeds()
+    embeds = utils.commands_overview_embeds(commands)
     await inter.response.send_message(embeds=embeds)
     ```
 

--- a/tests/bot.py
+++ b/tests/bot.py
@@ -35,7 +35,7 @@ async def kick_member(inter: disnake.GuildCommandInteraction, member: disnake.Me
     """
 
 
-@bot.slash_command(name="command1")
+@bot.slash_command(name="command1", guild_ids=[947543739671412878, 1041563016199680090])
 @commands.cooldown(1, 15, commands.BucketType.default)
 async def command1(inter):
     """A cool slash command"""
@@ -136,9 +136,7 @@ async def help_command(
     else:
         guild_id, dm_only, nsfw, permissions = get_helper_query_attrs(inter)
 
-        commands = helply.get_all_commands(
-            guild_id, dm_only=dm_only, include_nsfw=nsfw, permissions=permissions
-        )
+        commands = helply.get_commands(dm_only=dm_only, include_nsfw=nsfw, permissions=permissions)
         if not commands:
             await inter.response.send_message(
                 "Could not find any available commands.", ephemeral=True
@@ -168,7 +166,7 @@ async def autocomplete_command_names(
 
     guild_id, dm_only, nsfw, permissions = get_helper_query_attrs(inter)
 
-    commands = helply.get_all_commands(
+    commands = helply.get_commands(
         guild_id, dm_only=dm_only, include_nsfw=nsfw, permissions=permissions
     )
 

--- a/tests/bot.py
+++ b/tests/bot.py
@@ -25,6 +25,7 @@ async def ping(inter: disnake.ApplicationCommandInteraction):
     description="Kick the target member",
     extras={"help": "Removes the target member from the guild", "category": "Admin"},
 )
+@commands.cooldown(1, 1, type=commands.BucketType.member)
 async def kick_member(inter: disnake.GuildCommandInteraction, member: disnake.Member):
     """Kick a member from the server
 
@@ -35,8 +36,21 @@ async def kick_member(inter: disnake.GuildCommandInteraction, member: disnake.Me
 
 
 @bot.slash_command(name="command1")
+@commands.cooldown(1, 15, commands.BucketType.default)
 async def command1(inter):
     """A cool slash command"""
+
+
+@command1.sub_command_group(name="child")
+@commands.cooldown(1, 10, commands.BucketType.user)
+async def command_group(inter):
+    ...
+
+
+@command_group.sub_command(name="grandchild")
+@commands.cooldown(1, 20, commands.BucketType.channel)
+async def command_grandchild(inter):
+    ...
 
 
 @bot.slash_command(name="command2")
@@ -202,3 +216,12 @@ if __name__ == "__main__":
 
     dotenv.load_dotenv()
     bot.run(os.getenv("TOKEN"))
+
+    # for command in bot.application_commands:
+    #     cooldown = command._buckets._cooldown
+    #     type_ = command._buckets._type
+    #     if not cooldown:
+    #         continue
+
+    #     print(type(type_), str(type_))
+    #     print(cooldown, type_)


### PR DESCRIPTION
This PR adds the ability to access and display command cooldowns.   That's pretty much it.

```py
command = helply.get_command(ID)
print(command.cooldown)

# Cooldown(rate=1, per=10, type="User")
```